### PR TITLE
[bugfix] Improve model download recovery

### DIFF
--- a/models.cmd
+++ b/models.cmd
@@ -26,15 +26,28 @@ set "BASE=stable-audio-3-%VARIANT%"
 if not exist "%OUT%" mkdir "%OUT%"
 
 call :dl "%VAR_REPO%" "%BASE%-dit-%DIT_SIZE%-v1.0-%ENC%.gguf"
+if errorlevel 1 exit /b 1
 call :dl "%VAR_REPO%" "%BASE%-%SAME%-v1.0-%ENC%.gguf"
+if errorlevel 1 exit /b 1
 call :dl "%VAR_REPO%" "%BASE%-conditioner-v1.0-F32.gguf"
+if errorlevel 1 exit /b 1
 call :dl "%SHARED%"   "t5gemma-b-b-ul2-encoder-0.3B-v1.0-F32.gguf"
+if errorlevel 1 exit /b 1
 call :dl "%SHARED%"   "t5gemma-b-b-ul2-v1.0-vocab.gguf"
+if errorlevel 1 exit /b 1
 echo [done] %VARIANT% (%ENCODING%) -^> %OUT%\
 exit /b 0
 
 :dl
-if exist "%OUT%\%~2" ( echo [ok] %~2 & exit /b )
-echo [download] %~1/%~2
-curl -fL --retry 3 -o "%OUT%\%~2" "https://huggingface.co/%~1/resolve/main/%~2"
-exit /b
+set "DST=%OUT%\%~2"
+if exist "%DST%" (
+    echo [check/resume] %~2
+) else (
+    echo [download] %~1/%~2
+)
+curl.exe -fL --retry 3 --continue-at - -o "%DST%" "https://huggingface.co/%~1/resolve/main/%~2"
+if errorlevel 1 (
+    echo [error] failed to download %~1/%~2
+    exit /b 1
+)
+exit /b 0

--- a/models.sh
+++ b/models.sh
@@ -40,10 +40,13 @@ BASE="stable-audio-3-$VARIANT"
 mkdir -p "$OUT"
 
 dl() {   # dl <repo> <filename>
-  local repo="$1" file="$2"
-  if [ -f "$OUT/$file" ]; then echo "[ok] $file"; return; fi
-  echo "[download] $repo/$file"
-  curl -fL --retry 3 -o "$OUT/$file" "https://huggingface.co/$repo/resolve/main/$file"
+  local repo="$1" file="$2" dst="$OUT/$file"
+  if [ -f "$dst" ]; then
+    echo "[check/resume] $file"
+  else
+    echo "[download] $repo/$file"
+  fi
+  curl -fL --retry 3 --continue-at - -o "$dst" "https://huggingface.co/$repo/resolve/main/$file"
 }
 
 dl "$VAR_REPO" "$BASE-dit-$DIT_SIZE-v1.0-$ENC.gguf"

--- a/models/README.md
+++ b/models/README.md
@@ -22,6 +22,33 @@ quality-critical, so they're always F32.
 ./models.sh --variant small-music    # or small-sfx; --encoding f32; --out DIR
 ```
 
+## faster official downloader
+
+If plain `curl` is slow on your connection, use the Hugging Face SDK downloader. It keeps the
+same filenames in `models/`, but uses Hugging Face's cache/local-dir metadata, concurrent file
+fetching, and recent `hf_xet` support:
+
+```bash
+python -m pip install -U "huggingface_hub"
+python tools/download_models.py --variant small-music --encoding f16
+```
+
+Set `HF_XET_HIGH_PERFORMANCE=1` before running it if you want Hugging Face's high-throughput Xet mode:
+
+```powershell
+$env:HF_XET_HIGH_PERFORMANCE = "1"
+python tools\download_models.py --variant small-music --encoding f16
+```
+
+```cmd
+set HF_XET_HIGH_PERFORMANCE=1
+python tools\download_models.py --variant small-music --encoding f16
+```
+
+```bash
+HF_XET_HIGH_PERFORMANCE=1 python tools/download_models.py --variant small-music --encoding f16
+```
+
 or download by hand from huggingface:
 
 - https://huggingface.co/thepatch/stable-audio-3-medium-GGUF
@@ -29,6 +56,11 @@ or download by hand from huggingface:
 - https://huggingface.co/thepatch/stable-audio-3-small-sfx-GGUF
 - https://huggingface.co/thepatch/t5gemma-b-b-ul2-GGUF  (shared encoder + tokenizer)
 
+## troubleshooting
+
+If generation fails with `[gguf] short read ...`, the named GGUF is incomplete, usually from an interrupted
+download. Rerun `models.sh` / `models.cmd`; the curl downloader resumes existing partial files. If it still
+fails, delete the named `.gguf` and run the downloader again.
+
 `sa3-generate --model <variant>` resolves this set from the naming convention above. lora adapters resolve the
 same way (`lora-<name>-*.gguf`) — see [`../loras`](../loras).
-

--- a/src/gguf_model.h
+++ b/src/gguf_model.h
@@ -8,7 +8,9 @@
 #include "ggml-backend.h"
 #include "gguf.h"
 
+#include <cerrno>
 #include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -18,11 +20,55 @@
 #include <string>
 #include <utility>
 #include <vector>
+#ifndef _WIN32
+#include <sys/types.h>
+#endif
 
 namespace sa3 {
 
 inline std::runtime_error gguf_error(const std::string& message) {
     return std::runtime_error("[gguf] " + message);
+}
+
+inline bool gguf_file_seek(FILE* f, uint64_t off) {
+#ifdef _WIN32
+    return _fseeki64(f, (long long)off, SEEK_SET) == 0;
+#else
+    return fseeko(f, (off_t)off, SEEK_SET) == 0;
+#endif
+}
+
+inline bool gguf_file_size(FILE* f, uint64_t& out) {
+#ifdef _WIN32
+    const long long cur = _ftelli64(f);
+    if (cur < 0) return false;
+    if (_fseeki64(f, 0, SEEK_END) != 0) return false;
+    const long long end = _ftelli64(f);
+    if (_fseeki64(f, cur, SEEK_SET) != 0 || end < 0) return false;
+    out = (uint64_t)end;
+    return true;
+#else
+    const off_t cur = ftello(f);
+    if (cur < 0) return false;
+    if (fseeko(f, 0, SEEK_END) != 0) return false;
+    const off_t end = ftello(f);
+    if (fseeko(f, cur, SEEK_SET) != 0 || end < 0) return false;
+    out = (uint64_t)end;
+    return true;
+#endif
+}
+
+inline std::string gguf_short_read_message(const char* path, const char* name,
+                                           uint64_t off, size_t expected,
+                                           size_t got, uint64_t file_size,
+                                           bool have_file_size) {
+    std::string msg = "short read while loading tensor " + std::string(name) +
+        " from " + std::string(path) + ": expected " + std::to_string(expected) +
+        " bytes at offset " + std::to_string(off) + ", got " + std::to_string(got);
+    if (have_file_size) msg += " (file size " + std::to_string(file_size) + " bytes)";
+    msg += ". The GGUF is probably incomplete; rerun models.sh/models.cmd to resume the download, "
+           "or delete this file and download it again.";
+    return msg;
 }
 
 // Pick the compute backend: a registered GPU device (CUDA when the CUDA backend is
@@ -179,26 +225,46 @@ inline GgufModel load_gguf(const char* path, ggml_backend_t backend = nullptr) {
     m.gguf = gguf_init_from_file(path, gp);
     if (!m.gguf) throw gguf_error("failed to open " + std::string(path));
 
-    m.buf = ggml_backend_alloc_ctx_tensors(m.ctx, m.backend);
-
     std::unique_ptr<FILE, int(*)(FILE*)> f(fopen(path, "rb"), fclose);
     if (!f) throw gguf_error("cannot read " + std::string(path));
-    const size_t data_off = gguf_get_data_offset(m.gguf);
-    std::vector<char> tmp;
+    const uint64_t data_off = (uint64_t)gguf_get_data_offset(m.gguf);
+    uint64_t file_size = 0;
+    const bool have_file_size = gguf_file_size(f.get(), file_size);
+
+    struct TensorRead {
+        ggml_tensor* tensor;
+        std::string name;
+        uint64_t off;
+        size_t nb;
+    };
+    std::vector<TensorRead> reads;
     for (ggml_tensor* cur = ggml_get_first_tensor(m.ctx); cur; cur = ggml_get_next_tensor(m.ctx, cur)) {
         const char* name = ggml_get_name(cur);
         const int idx = gguf_find_tensor(m.gguf, name);
-        const size_t off = data_off + gguf_get_tensor_offset(m.gguf, idx);
+        if (idx < 0) throw gguf_error("metadata missing tensor offset for " + std::string(name) + " in " + std::string(path));
+        const uint64_t off = data_off + (uint64_t)gguf_get_tensor_offset(m.gguf, idx);
         const size_t nb  = ggml_nbytes(cur);
-        tmp.resize(nb);
-#ifdef _WIN32
-        _fseeki64(f.get(), (long long)off, SEEK_SET);   // MSVC `long` is 32-bit; files exceed 2 GB
-#else
-        fseeko(f.get(), (off_t)off, SEEK_SET);
-#endif
-        if (fread(tmp.data(), 1, nb, f.get()) != nb) throw gguf_error("short read " + std::string(name));
-        ggml_backend_tensor_set(cur, tmp.data(), 0, nb);
-        m.tensors[name] = cur;
+        if (have_file_size && (off > file_size || nb > file_size - off)) {
+            const uint64_t avail64 = off < file_size ? file_size - off : 0;
+            const size_t available = avail64 > (uint64_t)nb ? nb : (size_t)avail64;
+            throw gguf_error(gguf_short_read_message(path, name, off, nb, available, file_size, true));
+        }
+        reads.push_back({cur, name, off, nb});
+    }
+
+    m.buf = ggml_backend_alloc_ctx_tensors(m.ctx, m.backend);
+
+    std::vector<char> tmp;
+    for (const TensorRead& r : reads) {
+        tmp.resize(r.nb);
+        if (!gguf_file_seek(f.get(), r.off)) {
+            throw gguf_error("seek failed while loading tensor " + r.name + " from " +
+                             std::string(path) + ": " + std::strerror(errno));
+        }
+        const size_t got = fread(tmp.data(), 1, r.nb, f.get());
+        if (got != r.nb) throw gguf_error(gguf_short_read_message(path, r.name.c_str(), r.off, r.nb, got, file_size, have_file_size));
+        ggml_backend_tensor_set(r.tensor, tmp.data(), 0, r.nb);
+        m.tensors[r.name] = r.tensor;
     }
     return m;
 }

--- a/tools/download_models.py
+++ b/tools/download_models.py
@@ -5,13 +5,16 @@ Fetches one model variant (DiT + SAME + conditioner) plus the shared T5Gemma enc
 + tokenizer, following the naming/repo layout in docs/DISTRIBUTION.md. Cross-platform
 (Windows + macOS/Linux), unlike a bash models.sh.
 
-  python3 -m pip install huggingface_hub
+  python3 -m pip install -U "huggingface_hub"
   python3 tools/download_models.py --variant medium --encoding f16
   HF_TOKEN=hf_... python3 tools/download_models.py --variant small-sfx   # if a repo is gated
 
+For the fastest official Hugging Face path, install a recent `huggingface_hub`
+(1.x installs `hf_xet`) and optionally set HF_XET_HIGH_PERFORMANCE=1.
+
 The HF namespace is not final yet (pending Stability packaging) — override with --namespace.
 """
-import argparse, os, sys
+import argparse, importlib.util, os, sys
 
 # TODO: confirm with Stability/Zach before publishing; override at runtime with --namespace.
 DEFAULT_NAMESPACE = "thepatch"
@@ -25,6 +28,28 @@ VARIANTS = {
 SHARED_REPO = "t5gemma-b-b-ul2-GGUF"
 
 
+def print_transfer_info():
+    try:
+        import huggingface_hub
+        from huggingface_hub import constants
+    except Exception:
+        return
+
+    xet_installed = importlib.util.find_spec("hf_xet") is not None
+    xet_disabled = bool(getattr(constants, "HF_HUB_DISABLE_XET", False))
+    xet_ready = xet_installed and not xet_disabled
+    xet_high_perf = bool(getattr(constants, "HF_XET_HIGH_PERFORMANCE", False))
+    transfer = "hf_xet" if xet_ready else "http"
+    print(f"[hf] huggingface_hub {huggingface_hub.__version__}; transfer={transfer}; "
+          f"HF_XET_HIGH_PERFORMANCE={'1' if xet_high_perf else '0'}")
+    if xet_disabled:
+        print("[hf] HF_HUB_DISABLE_XET=1, so Xet downloads are disabled.")
+    elif not xet_installed:
+        print('[hf] install "huggingface_hub[hf_xet]" or "hf_xet" for Xet-backed downloads.')
+    elif not xet_high_perf:
+        print("[hf] set HF_XET_HIGH_PERFORMANCE=1 for Hugging Face's high-throughput Xet mode.")
+
+
 def main():
     ap = argparse.ArgumentParser(description="Download sa3.cpp GGUF models from HuggingFace.")
     ap.add_argument("--variant", default="medium", choices=list(VARIANTS))
@@ -35,10 +60,10 @@ def main():
     args = ap.parse_args()
 
     try:
-        from huggingface_hub import hf_hub_download
+        from huggingface_hub import snapshot_download
         from huggingface_hub.utils import get_token
     except ImportError:
-        sys.exit("missing dependency: python3 -m pip install huggingface_hub")
+        sys.exit('missing dependency: python3 -m pip install -U "huggingface_hub"')
 
     enc = args.encoding.upper()                 # F16 / F32
     dit_size, same = VARIANTS[args.variant]
@@ -46,23 +71,34 @@ def main():
     shared   = f"{args.namespace}/{SHARED_REPO}"
     base     = f"stable-audio-3-{args.variant}"
 
-    # (repo, filename). conditioner/encoder/tokenizer are small + quality-critical -> always F32.
-    wanted = [
-        (var_repo, f"{base}-dit-{dit_size}-v1.0-{enc}.gguf"),
-        (var_repo, f"{base}-{same}-v1.0-{enc}.gguf"),
-        (var_repo, f"{base}-conditioner-v1.0-F32.gguf"),
-        (shared,   "t5gemma-b-b-ul2-encoder-0.3B-v1.0-F32.gguf"),
-        (shared,   "t5gemma-b-b-ul2-v1.0-vocab.gguf"),
+    # conditioner/encoder/tokenizer are small + quality-critical -> always F32.
+    variant_files = [
+        f"{base}-dit-{dit_size}-v1.0-{enc}.gguf",
+        f"{base}-{same}-v1.0-{enc}.gguf",
+        f"{base}-conditioner-v1.0-F32.gguf",
+    ]
+    shared_files = [
+        "t5gemma-b-b-ul2-encoder-0.3B-v1.0-F32.gguf",
+        "t5gemma-b-b-ul2-v1.0-vocab.gguf",
     ]
 
     os.makedirs(args.out, exist_ok=True)
     token = os.environ.get("HF_TOKEN") or get_token()
-    for repo, fname in wanted:
-        print(f"[download] {repo}/{fname}")
+    print_transfer_info()
+    for repo, files in [(var_repo, variant_files), (shared, shared_files)]:
+        print(f"[download] {repo}")
+        for fname in files:
+            print(f"           {fname}")
         try:
-            hf_hub_download(repo_id=repo, filename=fname, local_dir=args.out, token=token)
+            snapshot_download(
+                repo_id=repo,
+                allow_patterns=files,
+                local_dir=args.out,
+                max_workers=min(8, len(files)),
+                token=token,
+            )
         except Exception as e:
-            print(f"\n[error] could not download {repo}/{fname}", file=sys.stderr)
+            print(f"\n[error] could not download {repo}", file=sys.stderr)
             print("        If the repo is private, make sure the active token can read that namespace.", file=sys.stderr)
             print("        Fine-grained Hugging Face tokens must include repo.content.read for the org/user that owns the repo.", file=sys.stderr)
             raise


### PR DESCRIPTION
## Summary

Improves the first-run model download and GGUF-load failure path discovered in issue #1.

- Make `models.cmd` and `models.sh` resume interrupted curl downloads instead of silently accepting partial files.
- Make `models.cmd` fail fast when any model file download fails.
- Add detailed GGUF short-read diagnostics with file path, tensor, offset, expected bytes, available bytes, and recovery guidance.
- Update `tools/download_models.py` to use the official Hugging Face SDK `snapshot_download` path with targeted `allow_patterns`, concurrent workers, and transfer backend reporting.
- Document short-read troubleshooting plus the faster official Hugging Face/Xet downloader path, including `HF_XET_HIGH_PERFORMANCE=1` examples.

## Root Cause

The issue reporter's shared T5Gemma encoder hash did not match the published artifact. Because both `--encoding f16` and `--encoding f32` failed at `te.embed.weight`, the failure was in the shared T5 encoder file rather than the DiT/SAME encoding-specific files.

Refs #1

## Validation

- Rebuilt `sa3-generate` with Visual Studio CMake.
- Created a deliberately truncated T5 GGUF and verified the new loader error reports the exact file/tensor/byte details.
- Seeded a scratch `models/` folder with a corrupt 7-byte T5 encoder, ran `tools/download_models.py --variant small-music --encoding f16 --out <scratch>`, and verified all five resulting hashes matched the expected Hugging Face artifacts.
- Ran `sa3-generate --model small-music --models-dir <scratch> --encoding f16 --frames 2 --steps 1 --duration-padding 0` successfully.
- Ran `tools/download_models.py` through `py_compile`.
- Verified the new transfer diagnostic reports `hf_xet` availability and `HF_XET_HIGH_PERFORMANCE` state.