### PR TITLE
[feature] Add CPU thread controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ SA3_MODELS_DIR=models
 # Backend / performance (all optional):
 # SA3_DEVICE=cpu              # force CPU even in a GPU build (parity / debugging)
 # SA3_GPU=nvidia             # pick a GPU by 0-based index or name substring (multi-GPU machines)
+# SA3_THREADS=8              # CPU backend thread count (also available as --threads on CLI/server)
 # SA3_FLASH_ATTN=1           # fused flash attention — faster decode (see docs/BENCHMARKS.md)
 # SA3_SAME_FLASH_ATTN=full   # SAME-L decoder flash: full | local | 0   (use full; local is Metal-only)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ set them locally — see [`.env.example`](.env.example). precedence is **flag > 
 | adapters (`--lora <name>`) | `SA3_ADAPTERS_DIR` | `--adapters-dir` | = models dir |
 | source adapter exports | `SA3_SOURCE_LORAS_DIR` | `--source-loras-dir` | `loras/` |
 | prompt dice pools | `SA3_PROMPTS_DIR` | `--prompts-dir` | `prompts/` |
-| device / flash | `SA3_DEVICE` `SA3_GPU` `SA3_FLASH_ATTN` | — | auto |
+| device / cpu threads / flash | `SA3_DEVICE` `SA3_GPU` `SA3_THREADS` `SA3_FLASH_ATTN` | `--threads` | auto |
 
 build needs cmake + a c++17 compiler (Visual Studio 2022 on windows). cuda needs the CUDA
 Toolkit; vulkan needs the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home); metal is macOS-only.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -104,3 +104,22 @@ decode is where it pays off (medium f16, 12s, this 5070 laptop):
 the DiT gain is modest/within-noise; the decoder is the real win. on metal it helped through
 120s (see docs/METAL.md). vulkan pays a one-time shader compile on the first flash run.
 
+## CPU thread count (small-music)
+
+testing ground: Intel Core Ultra 9 275HX, CPU backend, `small-music` f16,
+`--duration 5 --steps 4 --duration-padding 0`. `--threads N` sets ggml's CPU
+backend thread count; `SA3_THREADS=N` does the same for any surface.
+
+| threads | total | t5_compute | dit_compute | dec_compute |
+|---|---:|---:|---:|---:|
+| 1  | 20.90 s | 0.87 s | 15.07 s | 3.54 s |
+| 2  | 8.80 s  | 0.46 s | 5.64 s  | 1.26 s |
+| 4  | 5.46 s  | 0.27 s | 3.02 s  | 0.74 s |
+| 8  | 3.90 s  | 0.17 s | 1.85 s  | 0.43 s |
+| 12 | 3.33 s  | 0.14 s | 1.41 s  | 0.33 s |
+| 16 | 3.09 s  | 0.12 s | 1.20 s  | 0.30 s |
+| 24 | 2.86 s  | 0.11 s | 1.07 s  | 0.25 s |
+
+for a longer radio-style chunk on the same CPU, `--duration 60 --steps 4
+--duration-padding 0` took 25.6s at the build default thread count and 9.4s
+with `--threads 24`.

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -18,7 +18,12 @@ subprocess and no HTTP. The header is [`src/libsa3.h`](../src/libsa3.h); the pip
 full contract is in [`src/libsa3.h`](../src/libsa3.h). The shape:
 
 ```c
-sa3_context* ctx = sa3_init(&cfg, err, sizeof err);        // load the models (blocks ~seconds)
+sa3_config_ex cfg = {0};
+cfg.config.models_dir = absolute_models_dir;
+cfg.config.variant = "small-music";
+cfg.config.encoding = "f16";
+cfg.cpu_threads = 8;                                      // CPU backend only; 0 = SA3_THREADS/default
+sa3_context* ctx = sa3_init_ex(&cfg, err, sizeof err);     // load the models (blocks ~seconds)
 sa3_audio audio = {0};
 sa3_generate(ctx, &req, &audio, err, sizeof err);          // prompt -> planar float samples (blocks)
 // or: sa3_generate_ex(ctx, &req_ex, &audio, err, sizeof err); // a2a / inpaint + chunk/cancel controls
@@ -33,6 +38,8 @@ sa3_free(ctx);     // destroy
 - **not reentrant** — serialize `sa3_generate` calls on a given context (one at a time).
 - **ownership** — `sa3_generate` allocates `audio.samples`; release it with `sa3_free_audio` (same
   library/CRT — don't `free()` it yourself across the DLL boundary).
+- **CPU threads** — `sa3_init_ex` lets a host set `cpu_threads` directly; `sa3_init` still honors
+  `SA3_THREADS` through the shared backend defaults.
 - **loras** — pass adapter names (resolved in the adapters dir) or full paths via the parallel `lora_names`/
   `lora_strengths` arrays. `sa3_convert_lora(safetensors, json, out_gguf, ...)` converts a `.safetensors`
   adapter to gguf in-process (no Python) — the demo calls it on import.
@@ -102,7 +109,8 @@ auto sa3_init_fn = (decltype(&sa3_init))GetProcAddress(dll, "sa3_init");   // �
 `.exe` for the standalone.
 
 **models:** the DAW's working directory is unknown, so don't rely on the `"models"` default — pass an absolute
-`sa3_config.models_dir` (bundle the ggufs, resolve the path at runtime, or read an env var like `SA3_MODELS_DIR`).
+`sa3_config.models_dir` / `sa3_config_ex.config.models_dir` (bundle the ggufs, resolve the path at runtime,
+or read an env var like `SA3_MODELS_DIR`).
 
 ## threading — the part that matters
 

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -13,6 +13,7 @@ for progress and, on completion, the base64 audio. That makes it a drop-in for a
 ./build/bin/Release/sa3-server.exe --model medium --encoding f16 --port 8006
 # args: --host (default 127.0.0.1) --port (8006) --model <variant> --encoding f16|f32
 #       --models-dir DIR (or SA3_MODELS_DIR) --adapters-dir DIR (or SA3_ADAPTERS_DIR)
+#       --threads N (or SA3_THREADS, CPU backend only)
 #       --prompts-dir DIR (or SA3_PROMPTS_DIR)
 #       --source-loras-dir DIR (or SA3_SOURCE_LORAS_DIR)
 ```

--- a/src/gguf_model.h
+++ b/src/gguf_model.h
@@ -71,6 +71,25 @@ inline std::string gguf_short_read_message(const char* path, const char* name,
     return msg;
 }
 
+inline int cpu_threads_from_env() {
+    const char* v = getenv("SA3_THREADS");
+    if (!v || !*v) return 0;
+    char* end = nullptr;
+    long n = strtol(v, &end, 10);
+    if (!end || *end != '\0' || n <= 0 || n > 1024) {
+        fprintf(stderr, "[sa3] ignoring invalid SA3_THREADS='%s' (expected a positive integer)\n", v);
+        return 0;
+    }
+    return (int)n;
+}
+
+inline void configure_cpu_threads(ggml_backend_t b, int n_threads) {
+    if (b && n_threads > 0 && ggml_backend_is_cpu(b)) {
+        ggml_backend_cpu_set_n_threads(b, n_threads);
+        fprintf(stderr, "[sa3] CPU threads: %d\n", n_threads);
+    }
+}
+
 // Pick the compute backend: a registered GPU device (CUDA when the CUDA backend is
 // linked) unless SA3_DEVICE=cpu forces CPU. In a CPU-only build the registry has no
 // GPU device, so this transparently returns the CPU backend — same code, both builds.
@@ -81,7 +100,7 @@ inline std::string gguf_short_read_message(const char* path, const char* name,
 // prefer the one with the most total memory (the discrete GPU). SA3_GPU overrides this:
 // a 0-based index into the GPU list, or a case-insensitive substring of the device name
 // (e.g. SA3_GPU=nvidia). CUDA builds expose a single GPU device, so this is a no-op there.
-inline ggml_backend_t make_backend() {
+inline ggml_backend_t make_backend(int cpu_threads = 0) {
     const char* dev = getenv("SA3_DEVICE");
     if (!(dev && strcmp(dev, "cpu") == 0)) {
         // Collect all GPU devices in registry order.
@@ -133,7 +152,9 @@ inline ggml_backend_t make_backend() {
             }
         }
     }
-    return ggml_backend_cpu_init();
+    ggml_backend_t b = ggml_backend_cpu_init();
+    configure_cpu_threads(b, cpu_threads > 0 ? cpu_threads : cpu_threads_from_env());
+    return b;
 }
 
 struct GgufModel {

--- a/src/libsa3.cpp
+++ b/src/libsa3.cpp
@@ -18,6 +18,7 @@ struct sa3_context {
     std::unique_ptr<sa3::Pipeline> pipe;
     sa3::ModelPaths paths;
     std::string adapters_dir;
+    int cpu_threads = 0;
 };
 
 static void set_err(char* err, int n, const std::string& m) {
@@ -63,7 +64,7 @@ static int sa3_generate_impl(sa3_context* ctx, const sa3_request* req, const sa3
     try {
         if (!ctx->pipe) {   // reload after sa3_unload()
             ctx->pipe = std::make_unique<sa3::Pipeline>();
-            ctx->pipe->load(ctx->paths);
+            ctx->pipe->load(ctx->paths, ctx->cpu_threads);
         }
         sa3::GenParams p;
         p.prompt = req->prompt ? req->prompt : "";
@@ -145,10 +146,9 @@ static int sa3_generate_impl(sa3_context* ctx, const sa3_request* req, const sa3
       catch (...)                     { set_err(err, err_len, "unknown error"); return 10; }
 }
 
-extern "C" {
-
-SA3_API sa3_context* sa3_init(const sa3_config* cfg, char* err, int err_len) {
+static sa3_context* sa3_init_impl(const sa3_config* cfg, int cpu_threads, char* err, int err_len) {
     try {
+        if (cpu_threads < 0) { set_err(err, err_len, "cpu_threads must be positive"); return nullptr; }
         std::string models_dir = cfg && cfg->models_dir ? cfg->models_dir : "";
         if (models_dir.empty()) { const char* e = std::getenv("SA3_MODELS_DIR"); models_dir = (e && *e) ? e : "models"; }
         const std::string variant  = cfg && cfg->variant  ? cfg->variant  : "medium";
@@ -161,11 +161,22 @@ SA3_API sa3_context* sa3_init(const sa3_config* cfg, char* err, int err_len) {
         auto ctx = std::make_unique<sa3_context>();
         ctx->paths = mp;
         ctx->adapters_dir = adir;
+        ctx->cpu_threads = cpu_threads;
         ctx->pipe = std::make_unique<sa3::Pipeline>();
-        ctx->pipe->load(mp);
+        ctx->pipe->load(mp, ctx->cpu_threads);
         return ctx.release();
     } catch (const std::exception& e) { set_err(err, err_len, e.what()); return nullptr; }
       catch (...)                     { set_err(err, err_len, "unknown error"); return nullptr; }
+}
+
+extern "C" {
+
+SA3_API sa3_context* sa3_init(const sa3_config* cfg, char* err, int err_len) {
+    return sa3_init_impl(cfg, 0, err, err_len);
+}
+
+SA3_API sa3_context* sa3_init_ex(const sa3_config_ex* cfg, char* err, int err_len) {
+    return sa3_init_impl(cfg ? &cfg->config : nullptr, cfg ? cfg->cpu_threads : 0, err, err_len);
 }
 
 SA3_API int sa3_generate(sa3_context* ctx, const sa3_request* req, sa3_audio* out, char* err, int err_len) {
@@ -185,7 +196,7 @@ SA3_API void sa3_unload(sa3_context* ctx) { if (ctx) ctx->pipe.reset(); }   // d
 
 SA3_API void sa3_free(sa3_context* ctx) { delete ctx; }
 
-SA3_API const char* sa3_version(void) { return "sa3.cpp libsa3 2"; }
+SA3_API const char* sa3_version(void) { return "sa3.cpp libsa3 3"; }
 
 SA3_API int sa3_convert_lora(const char* safetensors_path, const char* json_path,
                              const char* out_gguf_path, char* err, int err_len) {

--- a/src/libsa3.h
+++ b/src/libsa3.h
@@ -40,6 +40,13 @@ typedef struct {
     const char* encoding;
 } sa3_config;
 
+/* Extended init options. Keeps the original sa3_config layout intact for existing callers.
+ * cpu_threads: 0 -> SA3_THREADS/default; >0 sets ggml CPU backend threads for this context. */
+typedef struct {
+    sa3_config config;
+    int cpu_threads;
+} sa3_config_ex;
+
 /* Optional progress callback. fraction is overall 0..1 (UI does *100); stage is
  * "sampling" | "decoding" | "done". Called on the sa3_generate() thread. */
 typedef void (*sa3_progress_cb)(void* user, const char* stage, int step, int total, float fraction);
@@ -153,6 +160,9 @@ typedef struct {
 
 /* Load the models. Returns NULL on failure, writing a message into err (if err && err_len > 0). */
 SA3_API sa3_context* sa3_init(const sa3_config* cfg, char* err, int err_len);
+
+/* Extended init with CPU thread override. */
+SA3_API sa3_context* sa3_init_ex(const sa3_config_ex* cfg, char* err, int err_len);
 
 /* Generate. Returns 0 on success (out filled), non-zero on failure (err filled). Not reentrant. */
 SA3_API int sa3_generate(sa3_context* ctx, const sa3_request* req, sa3_audio* out, char* err, int err_len);

--- a/src/sa3_pipeline.h
+++ b/src/sa3_pipeline.h
@@ -404,7 +404,7 @@ public:
 
     // Load all nets onto one shared backend (the GPU if available; SA3_DEVICE=cpu forces CPU).
     // Throws std::runtime_error on a missing/!@#$ file. Idempotent guard: load() once per Pipeline.
-    void load(const ModelPaths& paths);
+    void load(const ModelPaths& paths, int cpu_threads = 0);
     bool loaded() const { return loaded_; }
 
     // Run one generation. At entry it (re)loads any net a prior frugal (keep_models=false) call freed,
@@ -445,10 +445,10 @@ inline void Pipeline::ensure_nets_loaded() {
     nets_resident_ = true;
 }
 
-inline void Pipeline::load(const ModelPaths& paths) {
+inline void Pipeline::load(const ModelPaths& paths, int cpu_threads) {
     if (loaded_) return;
     paths_ = paths;
-    backend_ = make_backend();
+    backend_ = make_backend(cpu_threads);
     tok_ = Tokenizer::load(paths_.tok.c_str());
     ensure_nets_loaded();
     tc_ = T5GemmaConfig::from(TE_);

--- a/tools/sa3-generate.cpp
+++ b/tools/sa3-generate.cpp
@@ -47,7 +47,8 @@ int main(int argc, char** argv) {
     int encode_chunk_size = 0, encode_overlap = 32;     // outer SAME-L encode tiling; 0 = monolithic
     int decode_chunk_size = 0, decode_overlap = 32;     // outer SAME-L decode tiling; 0 = monolithic
     int frames = 128, steps = 8; long long seed = 0;   // seed < 0 (e.g. -1) => random (resolved below)
-    bool frames_set = false, duration_set = false;
+    int cpu_threads = 0;
+    bool frames_set = false, duration_set = false, threads_set = false;
     double duration_sec = 0.0;
     std::string dist_shift = "LogSNR";                  // schedule warp: LogSNR|Flux|Full|None
     float ds_p1 = 2000.0f, ds_p2 = -6.2f, ds_p3 = 0.0f, ds_p4 = 2.0f;   // LogSNR defaults (per-type, see --dist-shift)
@@ -70,6 +71,7 @@ int main(int argc, char** argv) {
         else if (!strcmp(argv[i], "--frames") && i+1 < argc) { frames = atoi(argv[++i]); frames_set = true; }
         else if (!strcmp(argv[i], "--duration") && i+1 < argc) { duration_sec = atof(argv[++i]); duration_set = true; }
         else if (!strcmp(argv[i], "--steps")  && i+1 < argc) steps = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--threads") && i+1 < argc) { cpu_threads = atoi(argv[++i]); threads_set = true; }
         else if (!strcmp(argv[i], "--seed")   && i+1 < argc) seed = strtoll(argv[++i], nullptr, 10);
         else if (!strcmp(argv[i], "--out")    && i+1 < argc) wav_p = argv[++i];
         else if (!strcmp(argv[i], "--init")   && i+1 < argc) init_p = argv[++i];
@@ -170,7 +172,7 @@ int main(int argc, char** argv) {
     if (!tok_p || !t5_p || !dit_p || !same_p) {
         fprintf(stderr, "usage: sa3-generate (--model medium|small-music|small-sfx [--encoding f16|f32] [--models-dir DIR]\n"
                         "                     | --tok <f> --t5 <f> --cond <f> --dit <f> --same <f>)\n"
-                        "                     --prompt \"...\" [--lora NAME|PATH [--lora-strength S]]... [--duration SEC | --frames N] [--steps N] [--seed S]\n"
+                        "                     --prompt \"...\" [--lora NAME|PATH [--lora-strength S]]... [--duration SEC | --frames N] [--steps N] [--threads N] [--seed S]\n"
                         "                     [--dist-shift LogSNR|Flux|Full|None [--dist-shift-params p1,p2,p3,p4]] [--duration-padding SEC]\n"
                         "                     [--cfg-scale S [--negative-prompt \"...\"] [--cfg-rescale R] [--cfg-interval min,max] [--apg-scale A] [--cfg-norm-threshold T]] [--out song.wav]\n");
         return 1;
@@ -200,6 +202,10 @@ int main(int argc, char** argv) {
     }
     if (frames <= 0) {
         fprintf(stderr, "--frames must be positive\n");
+        return 1;
+    }
+    if (threads_set && cpu_threads <= 0) {
+        fprintf(stderr, "--threads must be positive\n");
         return 1;
     }
     if (encode_chunk_size < 0 || encode_overlap < 0 ||
@@ -254,12 +260,14 @@ int main(int argc, char** argv) {
 
     try {
         sa3::Pipeline pipe;
-        pipe.load(paths);
+        pipe.load(paths, cpu_threads);
         sa3::GenResult r = pipe.generate(params);
         double tp = sa3::wall_time_s();
         sa3::write_wav_planar(wav_p, r.samples.data(), r.n_samp, r.n_ch, r.sample_rate);
         sa3::profile_log(prof, "write_wav", sa3::wall_time_s() - tp);
-        printf("wrote %s  (%.2fs, seed %llu)\n", wav_p, (float)r.n_samp / r.sample_rate, (unsigned long long)seed_resolved);
+        const double elapsed = sa3::wall_time_s() - t_total0;
+        printf("wrote %s  (audio %.2fs, elapsed %.2fs, seed %llu)\n",
+               wav_p, (float)r.n_samp / r.sample_rate, elapsed, (unsigned long long)seed_resolved);
     } catch (const std::exception& e) {
         fprintf(stderr, "error: %s\n", e.what());
         return 1;

--- a/tools/sa3-libtest.c
+++ b/tools/sa3-libtest.c
@@ -1,7 +1,7 @@
 /* sa3-libtest — a pure-C smoke test + minimal usage example for libsa3 (see src/libsa3.h).
  * This is exactly the call sequence a JUCE / IPlug2 host would use:
  *   sa3_init -> sa3_generate (with a progress callback) -> use samples -> sa3_free_audio -> sa3_free.
- *   usage: sa3-libtest ["prompt"] [out.wav]
+ *   usage: sa3-libtest ["prompt"] [out.wav] [cpu_threads]
  */
 #include "libsa3.h"
 
@@ -40,15 +40,17 @@ static void write_wav(const char* path, const float* planar, int n_samp, int n_c
 int main(int argc, char** argv) {
     const char* prompt = argc > 1 ? argv[1] : "warm analog house groove";
     const char* out    = argc > 2 ? argv[2] : "libsa3_test.wav";
+    const int cpu_threads = argc > 3 ? atoi(argv[3]) : 0;
     char err[512] = {0};
 
     printf("%s\n", sa3_version());
 
-    sa3_config cfg;
+    sa3_config_ex cfg;
     memset(&cfg, 0, sizeof cfg);
-    cfg.variant = "medium";
-    cfg.encoding = "f16";
-    sa3_context* ctx = sa3_init(&cfg, err, (int)sizeof err);
+    cfg.config.variant = "medium";
+    cfg.config.encoding = "f16";
+    cfg.cpu_threads = cpu_threads;
+    sa3_context* ctx = sa3_init_ex(&cfg, err, (int)sizeof err);
     if (!ctx) { fprintf(stderr, "sa3_init failed: %s\n", err); return 1; }
 
     sa3_request req;

--- a/tools/sa3-server.cpp
+++ b/tools/sa3-server.cpp
@@ -51,6 +51,7 @@ std::string g_models_dir;
 std::string g_adapters_dir;
 std::string g_prompts_dir;
 std::string g_source_loras_dir;
+int g_cpu_threads = 0;
 
 // --- async job registry (mirrors gary4local /poll_status) ---
 struct Job {
@@ -454,7 +455,7 @@ bool ensure_loaded(std::string& err) {
     if (!sa3::ModelPaths::resolve(g_models_dir, g_variant, g_encoding, mp, err)) return false;
     try {
         g_pipe = std::make_unique<sa3::Pipeline>();
-        g_pipe->load(mp);
+        g_pipe->load(mp, g_cpu_threads);
     } catch (const std::exception& e) { g_pipe.reset(); g_loaded = false; err = e.what(); return false; }
     g_loaded = true;
     return true;
@@ -733,6 +734,7 @@ int main(int argc, char** argv) {
     if (g_models_dir.empty()) g_models_dir = "models";
     if (g_prompts_dir.empty()) g_prompts_dir = "prompts";
     if (g_source_loras_dir.empty()) g_source_loras_dir = "loras";
+    bool threads_set = false;
     for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
         auto next = [&](const char* d){ return i + 1 < argc ? argv[++i] : d; };
@@ -744,6 +746,11 @@ int main(int argc, char** argv) {
         else if (a == "--adapters-dir") g_adapters_dir = next("");
         else if (a == "--prompts-dir")  g_prompts_dir = next("prompts");
         else if (a == "--source-loras-dir") g_source_loras_dir = next("loras");
+        else if (a == "--threads")      { g_cpu_threads = atoi(next("0")); threads_set = true; }
+    }
+    if (threads_set && g_cpu_threads <= 0) {
+        fprintf(stderr, "--threads must be positive\n");
+        return 1;
     }
     const std::string adir = g_adapters_dir.empty() ? g_models_dir : g_adapters_dir;
     const std::string pdir = g_prompts_dir;


### PR DESCRIPTION
## Summary

Refs #3.

Adds first-class CPU thread controls across the three ways sa3.cpp can run generation:

- `SA3_THREADS=N` for the shared CPU backend path
- `sa3-generate --threads N`
- `sa3-server --threads N`
- `sa3_init_ex(... cpu_threads ...)` for libsa3/plugin hosts

Also makes `sa3-generate` print both output audio duration and elapsed wall time, and documents the CPU thread benchmark results.

## Validation

- Built `sa3-generate`
- Built `sa3-server`
- Built `sa3_shared`, `sa3-libtest`, and `sa3-libcancel`
- Verified `--threads 0` rejects cleanly for CLI and server
- Verified `SA3_THREADS=8` and `--threads 8` both configure the CPU backend
- Verified `sa3_init_ex` rejects negative thread count before model load
- CPU benchmark: `small-music` f16, 5s output, 4 steps, no duration padding improved from 20.90s at 1 thread to 2.86s at 24 threads on an Intel Core Ultra 9 275HX
- Server smoke: two `keep_models:true` jobs with `--threads 24`, first completed in 2.85s including lazy load, second resident generation completed in 1.56s

## Notes

Draft while we continue checking server/libsa3 behavior and decide what CPU benchmark guidance belongs in the docs.