### PR TITLE
Loader errors: throw instead of exit(1)

### DIFF
--- a/tools/sa3-codec.cpp
+++ b/tools/sa3-codec.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -19,7 +20,7 @@ static std::vector<float> read_f32(const char* path, size_t n) {
     return b;
 }
 
-int main(int argc, char** argv) {
+static int run(int argc, char** argv) {
     const char* gguf_path = nullptr;
     const char* in_path = nullptr;
     const char* mode = "decode";
@@ -116,4 +117,13 @@ int main(int argc, char** argv) {
     ggml_free(ctx);
     W.free();
     return 0;
+}
+
+int main(int argc, char** argv) {
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "error: %s\n", e.what());
+        return 1;
+    }
 }

--- a/tools/sa3-dit.cpp
+++ b/tools/sa3-dit.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -18,7 +19,7 @@ static std::vector<float> read_f32(const char* path, size_t n) {
     return b;
 }
 
-int main(int argc, char** argv) {
+static int run(int argc, char** argv) {
     const char* gguf_path = nullptr; const char* dir = "refdata"; const char* outdir = "cppout";
     std::vector<std::pair<std::string,float>> lora_specs;   // (gguf, strength) in flag order
     int frames = 32, ctx_len = 257;
@@ -94,4 +95,13 @@ int main(int argc, char** argv) {
 
     ggml_gallocr_free(alloc); ggml_free(ctx); W.free();
     return 0;
+}
+
+int main(int argc, char** argv) {
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "error: %s\n", e.what());
+        return 1;
+    }
 }

--- a/tools/sa3-textenc.cpp
+++ b/tools/sa3-textenc.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -19,7 +20,7 @@ static std::vector<int32_t> read_i32(const char* path, size_t n) {
     return b;
 }
 
-int main(int argc, char** argv) {
+static int run(int argc, char** argv) {
     const char* gguf_path = nullptr; const char* ids_path = nullptr;
     const char* attn_path = nullptr; const char* outdir = ".";
     int seq = 256;
@@ -77,4 +78,13 @@ int main(int argc, char** argv) {
 
     ggml_gallocr_free(alloc); ggml_free(ctx); W.free();
     return 0;
+}
+
+int main(int argc, char** argv) {
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "error: %s\n", e.what());
+        return 1;
+    }
 }

--- a/tools/sa3-textmusic.cpp
+++ b/tools/sa3-textmusic.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -33,7 +34,7 @@ static void expo_features(float t, std::vector<float>& out, int dim, float min_f
     }
 }
 
-int main(int argc, char** argv) {
+static int run(int argc, char** argv) {
     const char* dit_path = nullptr; const char* same_path = nullptr;
     const char* dir = "refdata"; const char* outdir = "cppout"; const char* wav_path = "cppout/tm_ggml.wav";
     int frames = 64, steps = 8, ctx_len = 257;
@@ -144,4 +145,13 @@ int main(int argc, char** argv) {
     ggml_gallocr_free(alloc_dit); ggml_gallocr_free(alloc_dec);
     ggml_free(dctx); ggml_free(ectx); DIT.free(); AE.free();
     return 0;
+}
+
+int main(int argc, char** argv) {
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "error: %s\n", e.what());
+        return 1;
+    }
 }

--- a/tools/sa3-tokenize.cpp
+++ b/tools/sa3-tokenize.cpp
@@ -2,9 +2,10 @@
 #include "tokenizer.h"
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <string>
 
-int main(int argc, char** argv) {
+static int run(int argc, char** argv) {
     const char* tok_path = nullptr; std::string text;
     for (int i = 1; i < argc; i++) {
         if      (!strcmp(argv[i], "--tok")  && i+1 < argc) tok_path = argv[++i];
@@ -17,4 +18,13 @@ int main(int argc, char** argv) {
     for (size_t i = 0; i < ids.size(); i++) printf("%s%d", i ? ", " : "", ids[i]);
     printf("]\n");
     return 0;
+}
+
+int main(int argc, char** argv) {
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "error: %s\n", e.what());
+        return 1;
+    }
 }


### PR DESCRIPTION
## Summary
- `gguf_model.h`/`tokenizer.h`/`lora.h` now throw `std::runtime_error` on load failure instead of calling `exit(1)`, with RAII cleanup (unique_ptr guards for FILE*/gguf_context*/ggml_context*) so partial loads unwind cleanly.
- This lets the server's existing `try/catch` in `ensure_loaded()` (tools/sa3-server.cpp) actually catch model-load failures and report an error instead of the whole process dying on a single bad GGUF file.
- Added a thin `try/catch` wrapper around `main()` in the 5 standalone CLI tools (sa3-codec, sa3-dit, sa3-textenc, sa3-textmusic, sa3-tokenize) that call these loaders directly, so they keep their old behavior (clean stderr message + exit code 1) instead of an uncaught exception aborting via `std::terminate()`.

## Test plan
- [x] Release build of sa3-codec, sa3-dit, sa3-textenc, sa3-textmusic, sa3-tokenize, sa3-server all compile clean via MSBuild
- [x] Manual smoke test: pointed sa3-server at a models-dir with correctly-named but corrupt GGUF files. `/generate` queued the job, the worker thread's `ensure_loaded()` caught the throw from the tokenizer loader, the job status went to `"failed"` with `error: "[tok] failed to open ..."` via `/poll_status`, and the server kept accepting and correctly failing subsequent requests (`/health` stayed responsive throughout) instead of crashing the process.