### PR TITLE
[bugfix] Fix integrated GPU backend selection

### DIFF
--- a/src/gguf_model.h
+++ b/src/gguf_model.h
@@ -90,24 +90,27 @@ inline void configure_cpu_threads(ggml_backend_t b, int n_threads) {
     }
 }
 
-// Pick the compute backend: a registered GPU device (CUDA when the CUDA backend is
+// Pick the compute backend: a registered GPU/iGPU device (CUDA when the CUDA backend is
 // linked) unless SA3_DEVICE=cpu forces CPU. In a CPU-only build the registry has no
-// GPU device, so this transparently returns the CPU backend — same code, both builds.
+// GPU/iGPU device, so this transparently returns the CPU backend — same code, both builds.
 //
 // Device choice among GPUs: the Vulkan backend registers EVERY Vulkan device, so on a
 // laptop with an Intel iGPU + a discrete NVIDIA GPU the first-by-type device may be the
 // iGPU (wrong: tiny VRAM, slow). We therefore enumerate all GPU devices and, by default,
-// prefer the one with the most total memory (the discrete GPU). SA3_GPU overrides this:
-// a 0-based index into the GPU list, or a case-insensitive substring of the device name
+// prefer a discrete GPU, then the one with the most total memory. If only an integrated
+// GPU/APU is present, use that instead of silently falling back to CPU. SA3_GPU overrides this:
+// a 0-based index into the GPU/iGPU list, or a case-insensitive substring of the device name
 // (e.g. SA3_GPU=nvidia). CUDA builds expose a single GPU device, so this is a no-op there.
 inline ggml_backend_t make_backend(int cpu_threads = 0) {
     const char* dev = getenv("SA3_DEVICE");
     if (!(dev && strcmp(dev, "cpu") == 0)) {
-        // Collect all GPU devices in registry order.
+        // Collect all GPU/iGPU devices in registry order.
         std::vector<ggml_backend_dev_t> gpus;
         for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
             ggml_backend_dev_t d = ggml_backend_dev_get(i);
-            if (ggml_backend_dev_type(d) == GGML_BACKEND_DEVICE_TYPE_GPU) gpus.push_back(d);
+            const enum ggml_backend_dev_type type = ggml_backend_dev_type(d);
+            if (type == GGML_BACKEND_DEVICE_TYPE_GPU || type == GGML_BACKEND_DEVICE_TYPE_IGPU)
+                gpus.push_back(d);
         }
         if (!gpus.empty()) {
             ggml_backend_dev_t chosen = nullptr;
@@ -132,12 +135,21 @@ inline ggml_backend_t make_backend(int cpu_threads = 0) {
                 }
             }
             if (!chosen) {
-                // Default: the GPU with the most total memory (the discrete one).
+                // Default: prefer discrete GPUs over integrated GPUs/APUs. Within that class,
+                // pick the device with the most total memory.
                 size_t best = 0;
                 for (ggml_backend_dev_t d : gpus) {
+                    if (ggml_backend_dev_type(d) != GGML_BACKEND_DEVICE_TYPE_GPU) continue;
                     size_t free = 0, total = 0;
                     ggml_backend_dev_memory(d, &free, &total);
                     if (total > best) { best = total; chosen = d; }
+                }
+                if (!chosen) {
+                    for (ggml_backend_dev_t d : gpus) {
+                        size_t free = 0, total = 0;
+                        ggml_backend_dev_memory(d, &free, &total);
+                        if (total > best) { best = total; chosen = d; }
+                    }
                 }
                 if (!chosen) chosen = gpus[0];
             }
@@ -153,7 +165,10 @@ inline ggml_backend_t make_backend(int cpu_threads = 0) {
         }
     }
     ggml_backend_t b = ggml_backend_cpu_init();
-    configure_cpu_threads(b, cpu_threads > 0 ? cpu_threads : cpu_threads_from_env());
+    if (b) {
+        configure_cpu_threads(b, cpu_threads > 0 ? cpu_threads : cpu_threads_from_env());
+        fprintf(stderr, "[sa3] backend: %s\n", ggml_backend_name(b));
+    }
     return b;
 }
 


### PR DESCRIPTION
## Summary

This updates SA3 backend selection so ggml devices reported as `GGML_BACKEND_DEVICE_TYPE_IGPU` are treated as usable accelerators instead of being skipped. Discrete GPUs are still preferred when present, but APU/iGPU-only systems, such as the Radeon 780M reported in issue #6, should now initialize the HIP/Vulkan backend instead of silently falling back to CPU.

The CPU fallback path now also logs `[sa3] backend: CPU`, which should make future fallback cases easier to spot in user reports.

Refs #6

## Root Cause

The reporter's Vulkan log showed the AMD Radeon 780M was visible to ggml, followed by `[sa3] CPU threads: 16`. That points at SA3 falling back to the CPU backend after skipping the Vulkan device. ggml classifies integrated GPUs/APUs as `IGPU`, while SA3 was only collecting devices typed as discrete `GPU`.

## Validation

- `cmake --build build --config Release --target sa3-generate`
- `cmake --build build-vulkan --config Release --target sa3-generate`
- `cmake --build build-vulkan --config Release --target sa3-smoke`
- `git diff --check`
- Local hybrid Vulkan probe with `SA3_GPU=intel SA3_PROFILE=1 ./build-vulkan/bin/Release/sa3-generate.exe --model medium --prompt "space ambient" --duration 1 --steps 1 --out cppout/igpu_probe.wav`
  - Confirmed `[sa3] backend: Vulkan0 (Intel(R) Graphics, 36.1 GB)`
  - Completed generation successfully in 14.45s

## Notes

This still needs validation on the reporter's AMD/ROCm machine, since the local environment does not have the affected Radeon 780M/HIP setup.