### PR TITLE
dist-shift NaN guards + server per-phase progress (from #13)

### DIFF
--- a/src/sa3_pipeline.h
+++ b/src/sa3_pipeline.h
@@ -84,6 +84,13 @@ inline float dist_shift_warp(const std::string& type, float t, int seq_len,
     }
     if (type == "Flux") {
         const float min_length = p1, max_length = p2, alpha_min = p3, alpha_max = p4;
+        // Stale params from a dist-shift type switch (e.g. LogSNR params kept when switching to
+        // Flux, where max_length can be negative) make the log()s below NaN, silently poisoning
+        // the schedule -> silent WAV. Fall back to identity. NB: max==min is a VALID constant-alpha
+        // config (handled by the lmax==lmin bump), so guard strictly with < to preserve it.
+        if (min_length <= 0.0f || max_length <= 0.0f || max_length < min_length ||
+            alpha_min <= 0.0f || alpha_max <= 0.0f)
+            return t;
         const float sl = std::min(std::max((float)seq_len, min_length), max_length);
         const float lmin = std::log(min_length);
         float lmax = std::log(max_length);
@@ -96,6 +103,9 @@ inline float dist_shift_warp(const std::string& type, float t, int seq_len,
     }
     if (type == "Full") {
         const float base_shift = p1, max_shift = p2, min_length = p3, max_length = p4;
+        // max_length <= min_length divides by zero in the (sl-min)/(max-min) term below -> NaN.
+        if (max_length <= min_length || max_length <= 0.0f || min_length < 0.0f)
+            return t;
         const float sl = std::min(std::max((float)seq_len, min_length), max_length);
         const float mu = -(base_shift + (max_shift - base_shift) * (sl - min_length) / (max_length - min_length));
         const float em = std::exp(mu);
@@ -808,7 +818,7 @@ inline GenResult Pipeline::generate(const GenParams& params) {
         if (encode_chunk_size > 0 && sc.chunk)
             fprintf(stderr, "warning: outer chunked encode is only enabled for SAME-L; using monolithic SAME-S encode\n");
 
-        if (params.on_progress) params.on_progress({"encoding", 0, can_chunk_encode ? 1 : 1, 0.02f});
+        if (params.on_progress) params.on_progress({"encoding", 0, 1, 0.02f});
         if (!can_chunk_encode) {
             throw_if_cancelled(params.should_cancel);
             EncodeGraph eg = build_encode_graph(T);
@@ -1108,6 +1118,7 @@ inline GenResult Pipeline::generate(const GenParams& params) {
         DecodeGraph dg = build_decode_graph(T);
         run_decode_graph(dg, host_x.data(), ab);
         free_decode_graph(dg);
+        if (params.on_progress) params.on_progress({"decoding", 1, 1, 0.95f});  // match chunked path
         if (params.should_cancel && params.should_cancel())
             throw_cancelled_after_frugal_cleanup();
     } else {

--- a/tools/sa3-server.cpp
+++ b/tools/sa3-server.cpp
@@ -698,10 +698,13 @@ std::string queue_generation(sa3::GenParams params, uint64_t seed_resolved) {
             fflush(stderr);
             std::lock_guard<std::mutex> lk(jobs_mtx);
             auto it = jobs.find(sid); if (it == jobs.end()) return;
-            it->second.progress = (int)(p.fraction * 100.0f);
-            it->second.step     = p.step;
+            it->second.progress    = (int)(p.fraction * 100.0f);
+            it->second.step        = p.step;
+            it->second.total_steps = p.total;   // per-phase total (was locked at the sampling-step count)
             if      (!strcmp(p.stage, "sampling")) it->second.status = "generating";
-            else if (!strcmp(p.stage, "encoding") || !strcmp(p.stage, "decoding")) it->second.status = "encoding";
+            else if (!strcmp(p.stage, "encoding")) it->second.status = "encoding";
+            else if (!strcmp(p.stage, "decoding")) it->second.status = "decoding";
+            else if (!strcmp(p.stage, "done"))     it->second.status = "finalizing";
         };
         std::lock_guard<std::mutex> lk(g_mtx);
         { std::lock_guard<std::mutex> jl(jobs_mtx); if (auto it = jobs.find(sid); it != jobs.end()) it->second.status = "generating"; }


### PR DESCRIPTION
Adopts the safe, correct subset of #13. Verified on CPU/medium.

## Included
- **Flux/Full dist-shift NaN guards** — stale/mismatched `dist_shift_params` (e.g. LogSNR params kept after switching to Flux, giving `max_length=-6.2`) made `log()` NaN and silently poisoned the whole schedule, producing a dead WAV. Both now fall back to the identity schedule. Flux guards with strict `max < min` so the valid constant-alpha (`max==min`) config still works; Full uses `<=` because there `max==min` is a real divide-by-zero.
- **Server per-phase progress** — `total_steps` was pinned to the sampling step count, so encode/decode phases showed e.g. `encoding 0/10`. Now tracks the per-phase `Progress.total`, and `encoding`/`decoding`/`done` get distinct status labels (decode was previously mislabeled `encoding`).
- **Monolithic decode completion tick** (matches the chunked path) + removal of a dead `can_chunk_encode ? 1 : 1` ternary.

## Verified
- Valid `Full`/`Flux` generation unaffected (guards don't trigger on good params).
- `Flux` with stale LogSNR-style params now yields valid audio (identity fallback, energy 1.48e9) instead of a silent NaN WAV.
- `sa3-generate` and `sa3-server` build.

## Deliberately NOT included from #13
- **CUDA-graphs CC gate** — force-disables `GGML_CUDA_GRAPHS` for `-DCMAKE_CUDA_ARCHITECTURES=native` (the repo's own `build.cmd` default) even on Ampere+ GPUs, contradicting its own comment. Reproduced across arch values.

Based on fixes reported by pillopaus-project in #13.