### PR TITLE
train: add Vulkan backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # stable-audio-3 in c++
 
-> **update 7/15/2026 — CUDA and CPU LoRA training are now implemented via CLI. training is currently
-> tested on CUDA and CPU only. the trainer is in very active development, so expect changes as i
-> work toward all-backend training. Vulkan is in active development, with Metal planned shortly after.**
+> **update 7/16/2026 — Vulkan backend LoRA training is now implemented via CLI. Metal is up next.**
+>
+> **i'm still not super happy with training speed using iGPUs. hoping to improve that over the next
+> few days once we get the Metal backend working and i can circle back.**
 >
 > **nothing should be different for you at inference time, but plz let me know if any issues surface.**
 
@@ -77,13 +78,18 @@ Toolkit; vulkan needs the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home); meta
 backend + packaging details: [docs/DISTRIBUTION.md](docs/DISTRIBUTION.md) ·
 [docs/VULKAN.md](docs/VULKAN.md) · [docs/METAL.md](docs/METAL.md) · [docs/HIP.md](docs/HIP.md).
 there's also a small HTTP server (`./server.sh` / `server.cmd`) — see [docs/SERVER.md](docs/SERVER.md).
-native adapter training is documented in [docs/TRAINING.md](docs/TRAINING.md).
+native adapter training is documented in [docs/TRAINING.md](docs/TRAINING.md), with measured backend
+and PyTorch comparisons in [docs/TRAINING_BENCHMARKS.md](docs/TRAINING_BENCHMARKS.md).
 With the matching base DiT downloaded (`models.cmd --training-base` on Windows), the common training
 path is deliberately just one command after `env.cmd`:
 
 ```powershell
 sa3-train --dataset C:\dev\datasets\my-training-set --steps 1500
 ```
+
+On the 8 GB laptop 5070 used for development, the default medium-base CUDA recipe currently averages
+1.065 seconds per update: a projected 44 minutes for 2,500 steps, versus 74 minutes for the completed
+PyTorch reference job on the same machine.
 
 The validated medium-base DoRA recipe is the default; model, optimizer, crop, conditioning, and
 output settings remain available as overrides for advanced runs. Periodic checkpoints are

--- a/docs/GGML_FORK.md
+++ b/docs/GGML_FORK.md
@@ -14,6 +14,12 @@ The initial patch branch is `feature/sa3-training-v0.15.3`, based on upstream gg
 5. CPU and CUDA F16-weight support in `OUT_PROD` backward.
 6. Contiguous materialization for strided `GGML_OP_CONT` gradients.
 
+Vulkan training is layered on that reviewed pin in
+`feature/sa3-training-vulkan-v0.15.3`. Its four additional commits add Vulkan `OUT_PROD`
+backward support, tile and thread-tile the shader, cover the new F32/F16 and partial-tile cases in
+ggml's backend-op tests, and prevent a stale Windows `MATH_LIBRARY-NOTFOUND` cache entry from
+breaking reconfiguration.
+
 ## Updating the fork
 
 Keep the official repository as `upstream` and the SA3 fork as `origin` inside the submodule:
@@ -30,11 +36,12 @@ after confirming that upstream contains an equivalent implementation.
 
 Before updating the parent repository's gitlink:
 
-1. Build both CPU and CUDA configurations.
-2. Run the registered CTest suite on both configurations.
-3. Run one medium-base and one small-base training step.
-4. Apply each resulting adapter through `sa3-generate`.
-5. Push the ggml branch and verify its exact commit is visible on the fork.
+1. Build every affected CPU, CUDA, Vulkan, or Metal configuration.
+2. Run the registered CTest suite on every affected configuration.
+3. Run ggml backend-op coverage for any newly supported operation and device class.
+4. Run one medium-base and one small-base training step.
+5. Apply each resulting adapter through `sa3-generate`.
+6. Push the ggml branch and verify its exact commit is visible on the fork.
 
 Then update the pinned commit in `sa3.cpp`. A fresh-clone check is required before merging:
 
@@ -57,12 +64,13 @@ tag when Vulkan, Metal, or another backend adds patches; push a new tag and upda
 gitlink to its exact commit. Keep every published pin reachable from the public fork so old
 `sa3.cpp` revisions remain buildable.
 
-| sa3.cpp milestone | upstream base | fork branch | pinned commit | trained backends |
-| --- | --- | --- | --- | --- |
-| trainer v1 | ggml `v0.15.3` (`eced84c`) | `feature/sa3-training-v0.15.3` | `cfec69c` | CPU, CUDA |
+| sa3.cpp milestone | immutable tag | upstream base | fork branch | pinned commit | trained backends |
+| --- | --- | --- | --- | --- | --- |
+| trainer v1 | `sa3-training-v1-cpu-cuda` | ggml `v0.15.3` (`eced84c`) | `feature/sa3-training-v0.15.3` | `cfec69c` | CPU, CUDA |
+| Vulkan v1 | `sa3-training-v1-vulkan` | ggml `v0.15.3` (`eced84c`) | `feature/sa3-training-vulkan-v0.15.3` | `5a87d69c` | CPU, CUDA, Vulkan |
 
-Add a row when the parent pin changes. A Vulkan milestone, for example, receives a new immutable
-tag and row rather than changing the trainer-v1 tag.
+Add a row when the parent pin changes. Metal and later backend milestones receive new immutable
+tags and rows rather than changing either existing trainer-v1 tag.
 
 ## Updating existing clones and downstream forks
 

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -151,7 +151,8 @@ order, plus the stochastic states used for crops, prompts, CFG dropout, inpainti
 diffusion noise. Keeping those tensors separate prevents inference from loading optimizer state.
 
 Pass either member of the pair to `--resume`. `--steps` is the total target step, not the number of
-additional updates. For example, this continues a step-500 CPU or CUDA run through step 1500:
+additional updates. For example, this continues a step-500 CPU, CUDA, or Vulkan run through step
+1500:
 
 ```powershell
 sa3-train --dataset C:\datasets\my-training-set --resume C:\dev\sa3.cpp\train-runs\my-training-set\trainer-state-step-500.gguf --steps 1500

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -2,19 +2,25 @@
 
 `sa3-train` trains a DiT LoRA/DoRA adapter directly in C++/ggml from MP3/caption pairs and writes an adapter GGUF that loads through the existing `sa3-generate --lora` path.
 
-Training is currently validated on CUDA and CPU. Vulkan training is in active development; Metal is
+Training is currently validated on CUDA, Vulkan, and CPU. Vulkan v1 supports both discrete GPUs and
+integrated GPUs, although iGPU throughput still has substantial room for improvement. Metal is
 planned next. These training additions do not alter the existing inference path.
+
+Measured training throughput and reproducible backend comparisons are collected in
+[TRAINING_BENCHMARKS.md](TRAINING_BENCHMARKS.md).
 
 ## Build
 
 ```sh
 ./build.sh cpu
 ./build.sh cuda
+./build.sh vulkan
 ```
 
-CUDA is the fastest validated backend for real training runs. CPU training is also supported and
-honors the same thread controls as inference. See [NON_GPU_TESTS.md](NON_GPU_TESTS.md) for the
-registered CTest suite.
+CUDA is the fastest validated backend for real training runs. Vulkan training is supported on both
+integrated and discrete GPUs, and CPU training honors the same thread controls as inference. See
+[TRAINING_BENCHMARKS.md](TRAINING_BENCHMARKS.md) for measured throughput and
+[NON_GPU_TESTS.md](NON_GPU_TESTS.md) for the registered CTest suite.
 
 ## Models
 
@@ -186,3 +192,4 @@ build-cuda/bin/sa3-generate \
 - Split contamination: remove the duplicate item from train or held-out splits.
 - FFmpeg decode failure: confirm `ffmpeg` is installed and can decode the MP3.
 - CUDA build failure: verify the CUDA Toolkit is installed and rerun `./build.sh cuda`.
+- Vulkan build failure: verify the Vulkan SDK is installed and rerun `./build.sh vulkan`.

--- a/docs/TRAINING_BENCHMARKS.md
+++ b/docs/TRAINING_BENCHMARKS.md
@@ -1,0 +1,135 @@
+# Training Benchmarks
+
+These measurements cover native `sa3-train` update speed. They are separate from the generation
+benchmarks in [BENCHMARKS.md](BENCHMARKS.md). Unless noted otherwise, projected run times multiply
+the mean steady-step time by the requested step count and exclude model loading, pre-encoding, and
+checkpoint writes.
+
+## Test system
+
+- Windows, Intel Core Ultra 9 275HX (24 cores / 24 logical processors)
+- Intel Graphics, driver `32.0.101.6629`, Vulkan UMA backend
+- NVIDIA GeForce RTX 5070 Laptop GPU, Vulkan discrete-GPU backend with NV cooperative matrices
+- 64 GB system memory
+- F16 training-base DiTs, default DoRA-rows rank/alpha 16 recipe
+- Batch size 1, pre-encoded ratatat latents, seed 42
+- sa3.cpp `d7939a2`, ggml `5a87d69c`
+
+## Headline: medium-base CUDA versus PyTorch
+
+This is the default production recipe: medium-base F16, 512 latent frames (~23.8 seconds), batch
+size 1, DoRA-rows rank/alpha 16, checkpointed backward graphs, and the same pre-encoded ratatat
+latents. Both implementations ran on the RTX 5070 Laptop GPU.
+
+| implementation | timing source | steady step | throughput | 2,500 updates |
+|---|---|---:|---:|---:|
+| **sa3.cpp CUDA** | steps 2-50, `SA3_TRAIN_PROFILE=1` | **1,065.4 ms** | **0.939 steps/s** | **44 min 24 s projected** |
+| PyTorch 2.7.1 + CUDA 12.8 | checkpoint timestamps, steps 500-2,500 | 1,775.0 ms | 0.563 steps/s | 73 min 58 s steady / **74 min 2 s recorded process** |
+
+The native C++ trainer is **1.67x faster** on this workload, reducing projected training time by
+40.0%. The completed PyTorch process time includes model startup and five step checkpoints; the C++
+figure is a steady-step projection and excludes startup and checkpoint writes. A full native
+2,500-step run should be recorded before replacing the projection with an observed wall time.
+
+The C++ steady-step breakdown was:
+
+| sampled steps | T5 | prep | DiT forward/backward | AdamW | total / step |
+|---:|---:|---:|---:|---:|---:|
+| 2-50 | 8.2 ms | 1.8 ms | 986.2 ms | 69.2 ms | **1,065.4 ms** |
+
+The C++ measurement used:
+
+```bat
+set "SA3_GPU=" && set "SA3_TRAIN_PROFILE=1" && build-cuda\bin\Release\sa3-train.exe --dataset C:\dev\datasets\ratatat-train --latents-dir "C:\path\to\encoded\latents\sa3-medium" --steps 50 --out train-runs\cuda-medium-defaults-benchmark-50
+```
+
+The successful PyTorch reference job used mixed-F16 base weights, variable-length Flash Attention,
+and 229 adapter targets. The sa3.cpp default intentionally excludes the tiny `seconds_total`
+conditioner target and trains the 228 DiT Linear/Conv targets recommended for small datasets. This
+one-target scope difference is disclosed for precision; it is not large enough to explain the
+measured speedup by itself.
+
+## Validated full run: small-music CUDA
+
+The `train-runs/ratatat-train` run provides a complete native end-to-end measurement rather than a
+short-run projection:
+
+| model | frames | updates | latent source | checkpoints | wall time | effective time / update |
+|---|---:|---:|---|---|---:|---:|
+| `small-music` F16 base | 512 | 2,000 | native pre-encode | 500, 1,000, 1,500, 2,000 | **16 min 10 s observed** | **485 ms** |
+
+The output directory and configuration snapshot were created at 2:04:39 PM; the step-2,000 and
+final adapters were written at 2:20:49 PM. This wall time therefore includes model startup, native
+audio pre-encoding, all training updates, four checkpoints, and the final adapter write.
+
+The checkpoint intervals were:
+
+| interval | elapsed | average step |
+|---|---:|---:|
+| start to 500 | 4 min 8 s | 496 ms |
+| 500 to 1,000 | 3 min 54 s | 468 ms |
+| 1,000 to 1,500 | 4 min 2 s | 484 ms |
+| 1,500 to 2,000 | 4 min 6 s | 492 ms |
+
+The command recorded by the trainer was:
+
+```bat
+sa3-train --dataset C:\dev\datasets\ratatat-train --steps 2000 --model small-music
+```
+
+## Intel iGPU: small-music Vulkan training
+
+The backend was pinned with `SA3_GPU=intel`. Step 1 was excluded as graph setup/warm-up; the table
+uses the subsequent stable steps printed by `SA3_TRAIN_PROFILE=1`.
+
+| latent frames | audio context | sampled steps | T5 | prep | DiT | AdamW | total / step | projected 2,500 steps |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 512 | ~23.8 s | 2-5 | 104.8 ms | 2.0 ms | 9,034.3 ms | 32.5 ms | **9,173.5 ms** | **6 h 22 min** |
+| 256 | ~11.9 s | 2-6 | 100.2 ms | 1.0 ms | 5,383.8 ms | 33.2 ms | **5,518.6 ms** | **3 h 50 min** |
+
+Reducing the crop from 512 to 256 frames cut steady total step time by 39.8% (1.66x throughput).
+This is not strict reference-recipe parity: the shorter crop reduces the musical context seen by
+each update. Stable Audio 3 is a variable-length model family, however, and maintainer guidance
+indicates that adapters trained on roughly 12-second clips can still generate well at longer
+durations during inference. A 256-frame crop is therefore a practical iGPU training option rather
+than merely a smoke-test setting, although 512 frames remains the reference-style default.
+
+The 256-frame run was launched from Command Prompt with:
+
+```bat
+set "SA3_GPU=intel" && set "SA3_TRAIN_PROFILE=1" && build-vulkan\bin\Release\sa3-train.exe --model small-music --dataset C:\dev\datasets\ratatat-train --latents-dir "C:\path\to\encoded\latents\sa3-medium" --frames 256 --steps 50 --out train-runs\vulkan-intel-small-256
+```
+
+The existing latent cache deliberately removes native audio pre-encoding from the comparison. The
+profiled `total` is the training-step path; initial model loading and graph setup are also excluded.
+
+## 256-frame backend comparison
+
+The discrete-GPU and CPU comparisons used the same 256-frame model, latents, seed, dataset order,
+timesteps, and inpainting masks. The matching stochastic trajectory and closely aligned
+losses/gradient norms are also a useful cross-backend correctness check.
+
+| backend | sampled steps | T5 | prep | DiT | AdamW | total / step | projected 2,500 steps |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| RTX 5070 Laptop GPU, Vulkan | 2-6 | 12.6 ms | 1.6 ms | 666.0 ms | 34.2 ms | **714.2 ms** | **29 min 46 s** |
+| Intel Graphics, Vulkan | 2-6 | 100.2 ms | 1.0 ms | 5,383.8 ms | 33.2 ms | **5,518.6 ms** | **3 h 50 min** |
+| Core Ultra 9 275HX, CPU, 24 threads | 2-6 | 115.4 ms | 1.0 ms | 13,990.8 ms | 59.2 ms | **14,166.8 ms** | **9 h 50 min** |
+
+On this machine the discrete Vulkan GPU provides 7.73x the Intel iGPU throughput and 19.84x the CPU
+throughput. The Intel iGPU still provides 2.57x the CPU throughput, making it the more practical
+fallback for long runs when a discrete GPU is unavailable.
+
+The NVIDIA Vulkan run was pinned independently of CUDA with:
+
+```bat
+set "SA3_GPU=nvidia" && set "SA3_TRAIN_PROFILE=1" && build-vulkan\bin\Release\sa3-train.exe --model small-music --dataset C:\dev\datasets\ratatat-train --latents-dir "C:\path\to\encoded\latents\sa3-medium" --frames 256 --steps 50 --out train-runs\vulkan-nvidia-small-256
+```
+
+The CPU run explicitly cleared `SA3_GPU` to avoid carrying device selection over from the Vulkan
+terminal session:
+
+```bat
+set "SA3_GPU=" && set "SA3_TRAIN_PROFILE=1" && build\bin\Release\sa3-train.exe --model small-music --dataset C:\dev\datasets\ratatat-train --latents-dir "C:\path\to\encoded\latents\sa3-medium" --frames 256 --threads 24 --steps 50 --out train-runs\cpu-small-256-t24-50
+```
+
+Record steps 2 onward so graph setup does not skew the steady-state comparison.


### PR DESCRIPTION
## Summary

- enable native LoRA/DoRA training on ggml's Vulkan backend by implementing the `OUT_PROD` backward path used by adapter gradients
- support F32 and F16 frozen source weights, including partial tiles, with a tiled/thread-tiled compute shader
- avoid stale `MATH_LIBRARY-NOTFOUND` cache failures when reconfiguring Windows builds
- document Vulkan training, the pinned ggml milestone, and measured CUDA/Vulkan/CPU training performance

The parent repository changes only its pinned ggml commit plus documentation. No sa3 inference source was changed.

## ggml dependency

- fork branch: `feature/sa3-training-vulkan-v0.15.3`
- immutable tag: `sa3-training-v1-vulkan`
- pinned commit: `5a87d69ceb12e3eb28514164696c8156d16f8c6f`
- upstream base remains ggml `v0.15.3`

A fresh `--recurse-submodules` clone of this PR branch successfully fetched and checked out the exact pin from `betweentwomidnights/ggml`.

## Validation

- `build.cmd cpu`: pass
- `build.cmd cuda`: pass
- `build.cmd vulkan`: pass
- registered CTest suite: 16/16 on CPU, 16/16 on CUDA, 16/16 on Vulkan
- ggml `OUT_PROD` backend-op coverage: 91/91 supported cases on Intel Graphics and 91/91 on RTX 5070 Vulkan
- short `small-music` inference generation: pass on CPU, CUDA, Vulkan/NVIDIA, and Vulkan/Intel
- completed small-music Vulkan training run and ear test: pass
- medium Vulkan checkpoint/resume path: pass through steps 1–3 with adapter/state pairs preserved

## Performance notes

On this machine at 256 frames, the RTX 5070 Vulkan backend averaged 714.2 ms/update, Intel integrated Vulkan averaged 5.519 s/update, and the 24-thread CPU backend averaged 14.167 s/update. Vulkan iGPU training is functional and faster than CPU here, but its throughput still has substantial room for improvement. Metal training is planned next, followed by another iGPU optimization pass.

The new benchmark document also records the current default medium-base CUDA result (1.065 s/update, about 44 minutes projected for 2,500 updates) against the completed 74-minute PyTorch reference run.