### PR TITLE
functional LoRA: adapters on a quantized base, composed across a chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,12 +28,13 @@ bench/
 loras/*
 !loras/README.md
 
-# Model weights / checkpoints
+# Model weights / checkpoints (*.norms = derived base-norm cache, regenerated on demand)
 models/*
 !models/README.md
 checkpoints/
 train-runs/
 *.gguf
+*.norms
 *.safetensors
 metrics.jsonl
 config.snapshot.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,9 @@ target_link_libraries(sa3-train-inpaint-test PRIVATE sa3)
 add_executable(sa3-dit-lin-functional-test tests/dit_lin_functional_test.cpp)
 target_link_libraries(sa3-dit-lin-functional-test PRIVATE sa3)
 
+add_executable(sa3-lora-compose-test tests/lora_compose_test.cpp)
+target_link_libraries(sa3-lora-compose-test PRIVATE sa3)
+
 if(BUILD_TESTING)
     find_package(Python3 COMPONENTS Interpreter QUIET)
     add_test(NAME sa3-train-config-test COMMAND sa3-train-config-test)
@@ -243,6 +246,7 @@ if(BUILD_TESTING)
     add_test(NAME sa3-train-prompt-test COMMAND sa3-train-prompt-test)
     add_test(NAME sa3-train-inpaint-test COMMAND sa3-train-inpaint-test)
     add_test(NAME sa3-dit-lin-functional-test COMMAND sa3-dit-lin-functional-test)
+    add_test(NAME sa3-lora-compose-test COMMAND sa3-lora-compose-test)
     if(Python3_Interpreter_FOUND)
         add_test(NAME sa3-model-artifacts-test
                  COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/tests/model_artifacts_test.py")

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -98,6 +98,57 @@ generation is basically a base generation plus ~0.1s per adapter. the in-place p
 a separate copy of the dora'd dit (~2.9gb) would push vram back over 8gb and thrash. on the
 host loops this same apply was ~14s.
 
+### functional apply — the path a quantized base needs (experimental)
+
+the in-place merge cannot run on a quantized base at all. it has to read `W` out and write
+`W_eff` back, and neither direction has a route for k-quant types: the graph path aborts in
+`ggml_cast` (`unsupported type combination (q6_K to f32)`) and the host path cannot re-pack an
+f32 result into Q4_K storage. so `--lora X --encoding q4_k_m` used to be a hard abort.
+
+the alternative is to not merge at all — hand the adapter tensors to `dit_lin` and let it fold
+them into the graph as `y = W@x + s·B@(A@x)` plus the dora row scale. `W` is then only ever an
+argument to `mul_mat`, and quantized `mul_mat` works everywhere. this is the same formulation
+the training graph already used; inference simply passed `dl = nullptr`. see `src/lora.h` for
+the derivation and the limits.
+
+medium, 20s output, 8 steps, kev (dora-rows, rank 16), warm, base-norm cache primed:
+
+| backend | path | dit_compute | total | peak vram |
+|---|---|---|---|---|
+| cuda | f16 + merged | 699 ms | 5653 ms | 2994 MiB |
+| cuda | q4_k_m + functional | 728 ms | **3545 ms** | **1278 MiB** |
+| vulkan | f16 + merged | 523 ms | 6674 ms | 3049 MiB |
+| vulkan | q4_k_m + functional | 712 ms | **4310 ms** | **1248 MiB** |
+
+37% faster end to end on cuda, 35% on vulkan, and ~58% less vram on both. note the win is not
+per-step: `dit_compute` is *worse* functionally (+4% cuda, +36% vulkan), because the residual
+matmuls are real per-step work that the merged path does once up front. the end-to-end gain
+comes from loading a 1532 MiB model instead of a 4399 MiB one. vulkan pays more per step than
+cuda for the same graph, so on a backend where load time did not dominate this could invert.
+
+two things make it viable rather than merely possible:
+
+- **precomputed row scale.** `dit_lin` recomputes the dora-rows norms every step via
+  `mul_mat(W, A)` over the full base weight, which it must do while training because A and B
+  move. at inference `W`, `A` and `B` are all frozen, so `magnitude/||W + s·A@B||_row` is a
+  constant. computing it once cut `dit_compute` from 885 ms to 722 ms (+47% → +20%).
+- **cached base norms.** `base_norm_sq` needs every targeted weight pulled to the host and
+  squared, ~1.5B elements for the medium dit: +3.4 s on q4_k_m and +4.6 s on f16 (worse there,
+  larger weights to transfer — not a quantization problem). it depends only on the base
+  weights, so it is cached in `<model>.gguf.norms`, keyed on the model's byte size. first run
+  6647 ms, every run after 3512 ms. the sidecar is 3.3 MB for 228 tensors and is
+  backend-independent — a cache written by cuda is reused by vulkan.
+
+output is unchanged. functional vs merged on the *same* f16 base is 0.991400 waveform cosine
+on cuda and 0.950966 on vulkan, against 0.9968 for identical weights across cuda/cpu and
+0.9714 for medium f16 across cuda/vulkan. vulkan is simply looser between any two paths; both
+sit far above the ~0.5 floor that two genuinely different trajectories produce.
+
+f16/f32 bases still merge by default — it costs nothing per step. the functional path engages
+when the base is quantized, or when `SA3_FUNCTIONAL_LORA` is set to a/b the two on f16.
+limits: one adapter, `lora` or `dora-rows` only. `DitLoraParam` holds a single A/B per target
+and dora does not commute, so composing several functionally is not a matter of summing them.
+
 ## flash attention (opt-in)
 
 `ggml_flash_attn_ext` is a fused attention op every gpu backend implements, so the same flag

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -119,12 +119,28 @@ medium, 20s output, 8 steps, kev (dora-rows, rank 16), warm, base-norm cache pri
 | cuda | q4_k_m + functional | 728 ms | **3545 ms** | **1278 MiB** |
 | vulkan | f16 + merged | 523 ms | 6674 ms | 3049 MiB |
 | vulkan | q4_k_m + functional | 712 ms | **4310 ms** | **1248 MiB** |
+| metal m4 | f16 + merged | 4925 ms | 13520 ms | 3071 MiB |
+| metal m4 | q4_k_m + functional | 6340 ms | **11720 ms** | **1973 MiB** |
 
-37% faster end to end on cuda, 35% on vulkan, and ~58% less vram on both. note the win is not
-per-step: `dit_compute` is *worse* functionally (+4% cuda, +36% vulkan), because the residual
-matmuls are real per-step work that the merged path does once up front. the end-to-end gain
-comes from loading a 1532 MiB model instead of a 4399 MiB one. vulkan pays more per step than
-cuda for the same graph, so on a backend where load time did not dominate this could invert.
+37% faster end to end on cuda, 35% on vulkan, 13% on metal, and ~58%/~59%/36% less memory. note
+the win is not per-step: `dit_compute` is *worse* functionally (+4% cuda, +36% vulkan, +22%
+metal), because the residual matmuls are real per-step work that the merged path does once up
+front. the end-to-end gain comes from loading a 1532 MiB model instead of a 4399 MiB one. vulkan
+pays more per step than cuda for the same graph, so on a backend where load time did not
+dominate this could invert.
+
+**on metal at 8 steps it already inverts, even on f16**: merging costs ~2.4 s up front there, and
+at 8 steps that outweighs the accumulated residual cost.
+
+| steps (metal m4, f16) | merged | functional |
+|---:|---:|---:|
+| 8 | 13.52 s | **12.18 s** |
+| 32 | 29.30 s | 29.97 s |
+
+crossover is ~20–25 steps and 8 is the common case, but the default is deliberately left alone:
+one machine and one adapter type is not enough to move it, and `dora-rows` merging also pays for
+the dora row work that a plain `lora` merge would not. if the crossover holds on cuda/vulkan too
+then the heuristic wants to be step-count aware rather than dtype-aware, which is its own change.
 
 two things make it viable rather than merely possible:
 
@@ -139,15 +155,62 @@ two things make it viable rather than merely possible:
   6647 ms, every run after 3512 ms. the sidecar is 3.3 MB for 228 tensors and is
   backend-independent — a cache written by cuda is reused by vulkan.
 
-output is unchanged. functional vs merged on the *same* f16 base is 0.991400 waveform cosine
-on cuda and 0.950966 on vulkan, against 0.9968 for identical weights across cuda/cpu and
-0.9714 for medium f16 across cuda/vulkan. vulkan is simply looser between any two paths; both
-sit far above the ~0.5 floor that two genuinely different trajectories produce.
+### multiple adapters compose exactly
+
+blending several adapters is central to how these models get used, so the functional path
+composes a whole chain rather than handling one adapter. merging sequentially (each adapter
+reading the previous one's `W_eff`, which is what `apply_loras` does) expands with no
+approximation into
+
+```
+y = c_0 ⊙ (W@x) + Σ_k s_k · c_k ⊙ (B_k @ (A_k @ x))
+c_0 = Π_{dora j} d_j        c_k = Π_{dora j, j >= k} d_j
+```
+
+with `d_j` the dora row scale of adapter `j`. every `c` is constant at inference, so they are
+precomputed once and folded into the term tensors — the per-step graph costs one broadcast
+multiply plus the residuals, regardless of how many adapters are stacked. a later dora rescaling
+earlier residuals is exactly why the chain does not commute, and the recursion preserves that.
+`tests/lora_compose_test.cpp` pins this against the real merge path over 16 chains.
+
+precompute reuses what one adapter already needed: `base_norm_sq` (unchanged, and still
+adapter-independent, so the sidecar stays valid), one `mul_mat(W, A_k)` per adapter, and one
+rank×rank gram per adapter *pair*. a purely additive chain needs no norms at all and skips the
+host read entirely.
+
+### accuracy
+
+judge this per forward pass, not per generation. **at one diffusion step, functional vs merged on
+the same f16 base is 0.999878 (one adapter) and 0.999876 (two adapters)** — composition adds no
+error. over 8 steps the same comparison lands anywhere from 0.977 to 0.9995 because a ~1e-4
+per-pass difference compounds into a different-but-valid trajectory; those numbers move with the
+prompt and seed and should not be read as a quality ordering. metal measured 0.999711 over 8
+steps, cuda 0.991400 and vulkan 0.950966, against 0.9968 for identical weights across cuda/cpu
+and 0.9714 for medium f16 across cuda/vulkan — vulkan is simply looser between any two paths.
+
+two composed adapters (kev + keygen, both dora-rows rank 16, 228 targets, cuda, 20s/8 steps):
+
+| path | dit_compute | total | peak vram |
+|---|---|---|---|
+| f16 + merged | 816 ms | 6724 ms | 3213 MiB |
+| q4_k_m + functional | 1033 ms | **4230 ms** | **1423 MiB** |
+
+37% faster end to end and 56% less vram, with a bigger per-step cost (+27%) than one adapter
+because there are now two residuals per target.
+
+### defaults and limits
 
 f16/f32 bases still merge by default — it costs nothing per step. the functional path engages
-when the base is quantized, or when `SA3_FUNCTIONAL_LORA` is set to a/b the two on f16.
-limits: one adapter, `lora` or `dora-rows` only. `DitLoraParam` holds a single A/B per target
-and dora does not commute, so composing several functionally is not a matter of summing them.
+when the base is quantized, or when `SA3_FUNCTIONAL_LORA` is set to anything but `0`, to a/b the
+two on f16.
+
+the supported families are the row-normalizing ones — `lora`, `dora-rows`, and their `-xs`
+variants (`U @ M_xs @ Vᵗ` is still rank-r, so it regroups into the same terms) — in any number
+and any mix. `dora-cols` and `bora` still fall back to merging, so they need f16/f32. their
+scale factors onto the *input* rather than the output, which needs a column norm of the base
+weighted by the row scales accumulated so far — chain-dependent, so unlike `base_norm_sq` it
+cannot be cached per base — plus cross terms contracting against `Wᵗ`, which quantized `mul_mat`
+does not support.
 
 ## flash attention (opt-in)
 

--- a/src/dit.h
+++ b/src/dit.h
@@ -56,6 +56,10 @@ struct DitLoraParam {
     ggml_tensor* B = nullptr;            // [rank, out]  trainable
     ggml_tensor* magnitude = nullptr;    // dora-rows [out] trainable, else null
     ggml_tensor* base_norm_sq = nullptr; // dora-rows [out] constant (Σ_in W² + in·eps), else null
+    // Inference-only shortcut: magnitude/||W + s·A@B||_row precomputed as [out]. Training must
+    // leave this null because A and B move every step; at inference W, A and B are all frozen,
+    // so the whole per-step norm reduction below collapses to one broadcast multiply.
+    ggml_tensor* row_scale = nullptr;
     float scale = 1.0f;                  // alpha / rank
     bool  dora = false;                  // apply dora-rows column normalization
     int64_t in = 0;                      // input dim (reference / eps bookkeeping)
@@ -84,7 +88,9 @@ inline ggml_tensor* dit_lin(ggml_context* ctx, const GgufModel& W, const std::st
         ggml_tensor* ax  = ggml_mul_mat(ctx, p->A, x);          // [rank, seq]
         ggml_tensor* bax = ggml_mul_mat(ctx, p->B, ax);         // [out, seq]
         y = ggml_add(ctx, y, ggml_scale(ctx, bax, p->scale));
-        if (p->dora) {
+        if (p->dora && p->row_scale) {
+            y = ggml_mul(ctx, y, p->row_scale);   // precomputed; see DitLoraParam::row_scale
+        } else if (p->dora) {
             // dora-rows: multiply each output row by magnitude[out] / ||(W+s·A@B)_col[out]||.
             // The per-out scalar factors out of the matmul, so it scales the LoRA output above.
             // norm_sq[out] = base_norm_sq + 2s·term2 + s²·term3, with (over rank r):

--- a/src/dit.h
+++ b/src/dit.h
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <map>
 #include <string>
+#include <vector>
 
 namespace sa3 {
 
@@ -45,24 +46,45 @@ struct DitConfig {
     }
 };
 
-// Functional LoRA/DoRA application, used only by the training graph (see functional-lora-speed-plan).
-// A DitLora maps a weight-tensor name -> its trainable adapter tensors. When `dl` is null (all
-// inference callers) or has no entry for `name`, dit_lin is byte-identical to nn::linear:
-// mul_mat(W,x) then optional bias. When an entry exists, the adapter is applied FUNCTIONALLY as
-// small rank-sized matmuls, so autodiff never forms a full [in,out] weight gradient (the out_prod
-// that made the materialized-effective-weight path ~27x slower than PyTorch).
+// Functional LoRA/DoRA application, used by the training graph (see functional-lora-speed-plan)
+// and by inference over a quantized base (see build_functional_lora in lora.h). A DitLora maps a
+// weight-tensor name -> its adapter tensors. When `dl` is null or has no entry for `name`, dit_lin
+// is byte-identical to nn::linear: mul_mat(W,x) then optional bias. When an entry exists, the
+// adapter is applied FUNCTIONALLY as small rank-sized matmuls, which serves both callers: autodiff
+// never forms a full [in,out] weight gradient (the out_prod that made the materialized-
+// effective-weight path ~27x slower than PyTorch), and W is only ever a mul_mat argument, so it
+// never has to be dequantized or rewritten.
+
+// One low-rank residual in a composed chain: scale · B @ (A @ x). See DitLoraParam::terms.
+struct DitLoraTerm {
+    ggml_tensor* A = nullptr;            // [in, rank]
+    ggml_tensor* B = nullptr;            // [rank, out]
+    float scale = 1.0f;                  // (alpha/rank) · strength
+};
+
 struct DitLoraParam {
+    // ---- training: one adapter, norms recomputed every step because A and B move ----
     ggml_tensor* A = nullptr;            // [in, rank]   trainable
     ggml_tensor* B = nullptr;            // [rank, out]  trainable
     ggml_tensor* magnitude = nullptr;    // dora-rows [out] trainable, else null
     ggml_tensor* base_norm_sq = nullptr; // dora-rows [out] constant (Σ_in W² + in·eps), else null
-    // Inference-only shortcut: magnitude/||W + s·A@B||_row precomputed as [out]. Training must
-    // leave this null because A and B move every step; at inference W, A and B are all frozen,
-    // so the whole per-step norm reduction below collapses to one broadcast multiply.
-    ggml_tensor* row_scale = nullptr;
     float scale = 1.0f;                  // alpha / rank
     bool  dora = false;                  // apply dora-rows column normalization
     int64_t in = 0;                      // input dim (reference / eps bookkeeping)
+
+    // ---- inference: a composed chain of N adapters, all row scales precomputed ----
+    // Sequentially merging adapters 1..N (each reading the previous effective weight, which is
+    // what apply_loras does) is EXACTLY equivalent to
+    //     y = base_scale ⊙ (W@x) + Σ_k scale_k · B'_k @ (A_k @ x)
+    // where the dora row scales are folded in as constants: with d_j the row scale of dora
+    // adapter j, the base carries the product of every d_j, and residual k carries the product
+    // of the d_j for adapters at position >= k (so a later dora rescales earlier residuals,
+    // which is exactly why the chain does not commute). Each B'_k is B_k with its constant
+    // row scale already baked in, so the per-step graph costs one broadcast multiply total
+    // rather than one per adapter. All of it is constant because W, A, B and magnitude are
+    // frozen at inference — build_functional_lora computes it once. Empty for training.
+    std::vector<DitLoraTerm> terms;
+    ggml_tensor* base_scale = nullptr;   // [out] constant, or null for 1.0 (no dora in the chain)
 };
 using DitLora = std::map<std::string, DitLoraParam>;
 
@@ -83,14 +105,22 @@ inline ggml_tensor* dit_lin(ggml_context* ctx, const GgufModel& W, const std::st
     // past VRAM into driver sysmem paging (the 25x slowdown).
     ggml_tensor* wl = w;
     ggml_tensor* y = ggml_mul_mat(ctx, wl, x);                 // [out, seq]
-    if (p) {
+    if (p && !p->terms.empty()) {
+        // Inference: a precomputed chain of N adapters. See DitLoraParam::terms — every dora
+        // row scale is already folded into base_scale and into each B'_k, so composing adapters
+        // costs nothing here beyond the residuals themselves.
+        if (p->base_scale) y = ggml_mul(ctx, y, p->base_scale);  // broadcast over seq
+        for (const DitLoraTerm& t : p->terms) {
+            ggml_tensor* ax  = ggml_mul_mat(ctx, t.A, x);        // [rank, seq]
+            ggml_tensor* bax = ggml_mul_mat(ctx, t.B, ax);       // [out, seq]
+            y = ggml_add(ctx, y, ggml_scale(ctx, bax, t.scale));
+        }
+    } else if (p) {
         // LoRA applied functionally: y += scale · B @ (A @ x)  (== mul_mat(W + s·A@B, x)).
         ggml_tensor* ax  = ggml_mul_mat(ctx, p->A, x);          // [rank, seq]
         ggml_tensor* bax = ggml_mul_mat(ctx, p->B, ax);         // [out, seq]
         y = ggml_add(ctx, y, ggml_scale(ctx, bax, p->scale));
-        if (p->dora && p->row_scale) {
-            y = ggml_mul(ctx, y, p->row_scale);   // precomputed; see DitLoraParam::row_scale
-        } else if (p->dora) {
+        if (p->dora) {
             // dora-rows: multiply each output row by magnitude[out] / ||(W+s·A@B)_col[out]||.
             // The per-out scalar factors out of the matmul, so it scales the LoRA output above.
             // norm_sq[out] = base_norm_sq + 2s·term2 + s²·term3, with (over rank r):

--- a/src/lora.h
+++ b/src/lora.h
@@ -12,6 +12,7 @@
 // plain lora:            W_eff = W0 + (alpha/rank)*strength*(B@A).  (additive, commutative)
 #pragma once
 
+#include "dit.h"          // DitLora / DitLoraParam, for the functional (unmerged) path below
 #include "ggml.h"
 #include "gguf_model.h"
 

--- a/src/lora.h
+++ b/src/lora.h
@@ -16,6 +16,7 @@
 #include "ggml.h"
 #include "gguf_model.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <filesystem>
@@ -249,10 +250,22 @@ inline LoraStack apply_loras(GgufModel& base, std::vector<LoraAdapter>& adapters
 // backend, so the base never has to be dequantized or rewritten. This is the same
 // formulation the training graph already uses; inference simply passed dl = nullptr.
 //
+// Adapters COMPOSE, in the same order and with the same semantics as the merge path. Merging
+// sequentially gives W_N where V_j = W_{j-1} + s_j·B_j@A_j and W_j = diag(d_j)·V_j for dora-rows,
+// which expands exactly (no approximation) into
+//     y = c_0 ⊙ (W@x) + Σ_k s_k · c_k ⊙ (B_k @ (A_k @ x)),
+//     c_0 = Π_{dora j} d_j,   c_k = Π_{dora j, j >= k} d_j.
+// Every d_j is constant at inference, so the c's are precomputed here and folded into the term
+// tensors; see DitLoraParam::terms. A later dora rescaling earlier residuals is precisely why
+// the chain does not commute, and the recursion below preserves that.
+//
 // Limits (both fall back to the merge path):
-//   - one adapter at a time. DitLoraParam holds a single A/B per target, and DoRA does not
-//     commute, so composing several functionally is not a matter of summing them.
-//   - "lora" and "dora-rows" only, matching what dit_lin implements.
+//   - the row-normalizing families only: "lora", "dora-rows" and their "-xs" variants.
+//     "dora-cols"/"bora" normalize over `in`, so their scale factors onto the INPUT rather than
+//     the output. Composing those functionally would need a column norm of the base weighted by
+//     the row scales accumulated so far — chain-dependent, so unlike base_norm_sq it cannot be
+//     cached per base — and cross terms of the form Σ_out W[o,i]·B[o,r], a contraction against
+//     Wᵀ that quantized mul_mat does not support. They stay merged, hence f16/f32 only.
 struct FunctionalLora {
     DitLora               map;
     ggml_context*         ctx = nullptr;   // owns the base_norm_sq constants
@@ -334,83 +347,109 @@ inline void save(const std::string& model_path, const std::map<std::string, std:
 
 } // namespace normcache
 
-inline bool functional_lora_ok(const std::vector<LoraAdapter>& adapters) {
-    if (adapters.size() != 1) return false;
-    const std::string& t = adapters[0].type;
-    return t == "lora" || t == "dora-rows";
+// "-xs" families store the low-rank update as U @ M_xs @ Vᵗ instead of B @ A. That is still
+// rank-r, so regrouping gives A_eff = (M_xs @ V)ᵗ and B_eff = U — the same term structure, one
+// small [in,rank] product computed once below.
+inline bool functional_lora_is_xs(const std::string& t) {
+    return t.size() >= 3 && t.compare(t.size() - 3, 3, "-xs") == 0;
 }
 
-// Build the dit_lin adapter map for `adapters[0]` over `base`. Adapter tensors must already
-// live on base.backend (load_lora(..., base.backend)); only the dora-rows base_norm_sq
-// constants are allocated here, computed on the host from W (quantized W included).
+inline bool functional_lora_family_ok(const std::string& t) {
+    return t == "lora" || t == "dora-rows" || t == "lora-xs" || t == "dora-rows-xs";
+}
+
+inline bool functional_lora_ok(const std::vector<LoraAdapter>& adapters) {
+    if (adapters.empty()) return false;
+    for (auto& a : adapters) if (!functional_lora_family_ok(a.type)) return false;
+    return true;
+}
+
+// Build the dit_lin adapter map for the whole `adapters` chain over `base`. Adapter tensors must
+// already live on base.backend (load_lora(..., base.backend)). Everything allocated here is a
+// constant: the per-target base row scale, the row-scaled B' for each residual, and the -xs A_eff.
+// The base weight W is read on the host only for base_norm_sq (cached in the sidecar); every other
+// use of W is a mul_mat, which is what lets a quantized base carry adapters at all.
 inline FunctionalLora build_functional_lora(GgufModel& base, std::vector<LoraAdapter>& adapters,
                                             const std::string& base_path = "") {
     FunctionalLora fl;
     if (!functional_lora_ok(adapters)) return fl;
-    LoraAdapter& a = adapters[0];
-    const bool dora = (a.type == "dora-rows");
 
-    std::map<std::string, std::vector<float>> nsq_cache;
-    bool cache_hit = false, cache_dirty = false;
-    if (dora && !base_path.empty()) cache_hit = normcache::load(base_path, nsq_cache);
+    // One adapter's contribution to one target, in chain order.
+    struct Entry {
+        size_t ai = 0;                 // index into `adapters` -- the chain order
+        bool   dora = false, xs = false;
+        bool   scaled = false;         // a dora at this position or later rescales this residual
+        float  scale = 1.0f;           // (alpha/rank) · strength
+        ggml_tensor* Aeff = nullptr;   // persistent [in,rank], -xs only
+        ggml_tensor* Bp   = nullptr;   // persistent [rank,out] B with its row scale baked in
+    };
+    struct Plan {
+        std::string wname, stem;
+        int64_t in = 0, out = 0;
+        bool any_dora = false;
+        std::vector<Entry> chain;
+        std::vector<float> nsq0;             // host base_norm_sq, only when any_dora
+        ggml_tensor* nsq0_t = nullptr;       // scratch upload of the above
+        ggml_tensor* base_scale = nullptr;   // persistent [out], only when any_dora
+    };
 
-    std::vector<std::string> targets;
+    // ---- plan every target: which adapters hit it, in order ----
+    std::vector<Plan> plans;
     for (auto& kv : base.tensors) {
         const std::string& wname = kv.first;
         if (wname.size() < 7 || wname.compare(wname.size()-7, 7, ".weight") != 0) continue;
-        if (a.gguf.has(wname.substr(0, wname.size()-7) + ".lora_A")) targets.push_back(wname);
-    }
-    if (targets.empty()) return fl;
-
-    // Two persistent f32 [out] constants per dora-rows target: base_norm_sq (host-computed)
-    // and row_scale (filled by the one-shot graph below).
-    ggml_init_params ip = { (2*targets.size()+4)*ggml_tensor_overhead(), nullptr, true };
-    fl.ctx = ggml_init(ip);
-    std::vector<ggml_tensor*> norms, scales;
-    std::vector<std::vector<float>> norm_host;
-    for (auto& wname : targets) {
-        ggml_tensor* W0 = base.tensors[wname];
-        const int64_t in = W0->ne[0], out = W0->ne[1];
-        std::string stem = wname.substr(0, wname.size()-7);
-        DitLoraParam p;
-        p.A     = a.gguf.get(stem + ".lora_A");
-        p.B     = a.gguf.get(stem + ".lora_B");
-        p.scale = (a.alpha / a.rank) * a.strength;
-        p.dora  = dora;
-        p.in    = in;
-        if (dora) {
-            p.magnitude = a.gguf.get(stem + ".magnitude");
-            // base_norm_sq[o] = Σ_in W[o,i]² + in·eps, matching train_row_norm_sq. Reading W
-            // here is the one place the base is touched outside a matmul, and read_to_f32
-            // dequantizes on the host, so it is fine for a quantized base. It is also the
-            // expensive part, hence the sidecar cache.
-            std::vector<float> nsq;
-            auto it = nsq_cache.find(wname);
-            if (it != nsq_cache.end() && it->second.size() == (size_t)out) {
-                nsq = it->second;
-            } else {
-                std::vector<float> w;  read_to_f32(W0, w);
-                nsq.assign((size_t)out, 0.0f);
-                for (int64_t o = 0; o < out; o++) {
-                    double s = 0.0;
-                    const float* wo = &w[(size_t)o*in];
-                    for (int64_t i = 0; i < in; i++) s += (double)wo[i]*wo[i];
-                    nsq[(size_t)o] = (float)(s + (double)in * 1e-12);
-                }
-                nsq_cache[wname] = nsq;
-                cache_dirty = true;
-            }
-            ggml_tensor* nt = ggml_new_tensor_1d(fl.ctx, GGML_TYPE_F32, out);
-            ggml_tensor* st = ggml_new_tensor_1d(fl.ctx, GGML_TYPE_F32, out);
-            norms.push_back(nt); scales.push_back(st); norm_host.push_back(std::move(nsq));
-            p.base_norm_sq = nt;
-            p.row_scale    = st;
+        const std::string stem = wname.substr(0, wname.size()-7);
+        Plan pl;
+        for (size_t ai = 0; ai < adapters.size(); ai++) {
+            LoraAdapter& a = adapters[ai];
+            Entry e;
+            e.ai   = ai;
+            e.xs   = functional_lora_is_xs(a.type);
+            e.dora = a.type == "dora-rows" || a.type == "dora-rows-xs";
+            if (!a.gguf.has(stem + (e.xs ? ".M_xs" : ".lora_A"))) continue;  // not targeted
+            if (a.strength == 0.0f) continue;                                // identity, as in the merge path
+            e.scale = (a.alpha / a.rank) * a.strength;
+            pl.chain.push_back(e);
+            pl.any_dora = pl.any_dora || e.dora;
         }
-        fl.map[wname] = p;
+        if (pl.chain.empty()) continue;
+        // residual k carries the row scales of every dora at position >= k (suffix scan)
+        for (size_t k = pl.chain.size(); k-- > 0; )
+            pl.chain[k].scaled = pl.chain[k].dora ||
+                                 (k + 1 < pl.chain.size() && pl.chain[k+1].scaled);
+        pl.wname = wname; pl.stem = stem;
+        pl.in = kv.second->ne[0]; pl.out = kv.second->ne[1];
+        plans.push_back(std::move(pl));
     }
-    fl.buf = ggml_backend_alloc_ctx_tensors(fl.ctx, base.backend);
-    for (size_t i = 0; i < norms.size(); i++)
-        ggml_backend_tensor_set(norms[i], norm_host[i].data(), 0, norm_host[i].size()*sizeof(float));
+    if (plans.empty()) return fl;
+
+    // ---- base_norm_sq, only if some adapter in some chain is dora ----
+    // Depends only on the base weights, never on the adapter, so it is shared by every LoRA ever
+    // loaded against this model and cached in the sidecar. A purely additive chain needs no norms
+    // at all and skips this entirely.
+    bool need_norms = false;
+    for (auto& pl : plans) need_norms = need_norms || pl.any_dora;
+    std::map<std::string, std::vector<float>> nsq_cache;
+    bool cache_hit = false, cache_dirty = false;
+    if (need_norms && !base_path.empty()) cache_hit = normcache::load(base_path, nsq_cache);
+    for (auto& pl : plans) {
+        if (!pl.any_dora) continue;
+        auto it = nsq_cache.find(pl.wname);
+        if (it != nsq_cache.end() && it->second.size() == (size_t)pl.out) { pl.nsq0 = it->second; continue; }
+        // nsq0[o] = Σ_in W[o,i]² + in·eps, matching train_row_norm_sq. read_to_f32 dequantizes on
+        // the host, so this works on a quantized base; it is also the expensive part (every
+        // targeted weight pulled down), hence the cache.
+        std::vector<float> w;  read_to_f32(base.tensors[pl.wname], w);
+        pl.nsq0.assign((size_t)pl.out, 0.0f);
+        for (int64_t o = 0; o < pl.out; o++) {
+            double s = 0.0;
+            const float* wo = &w[(size_t)o*pl.in];
+            for (int64_t i = 0; i < pl.in; i++) s += (double)wo[i]*wo[i];
+            pl.nsq0[(size_t)o] = (float)(s + (double)pl.in * 1e-12);
+        }
+        nsq_cache[pl.wname] = pl.nsq0;
+        cache_dirty = true;
+    }
     if (cache_dirty && !base_path.empty()) {
         normcache::save(base_path, nsq_cache);
         printf("lora: wrote base-norm cache %s\n", normcache::path_for(base_path).c_str());
@@ -418,41 +457,165 @@ inline FunctionalLora build_functional_lora(GgufModel& base, std::vector<LoraAda
         printf("lora: base-norm cache hit (%zu tensors)\n", nsq_cache.size());
     }
 
-    // Fill row_scale once. Deliberately the same op sequence dit_lin uses for the per-step
-    // path, so the shortcut cannot drift from the reference: nsq = base_norm_sq + 2s·t2 + s²·t3,
-    // row_scale = magnitude / sqrt(nsq). Every input here is frozen at inference, which is why
-    // this is a constant rather than per-step work.
-    if (!scales.empty()) {
-        const size_t nn = targets.size()*24 + 64;
+    // ---- persistent constants: base_scale, B', -xs A_eff ----
+    size_t ntensors = 0;
+    for (auto& pl : plans) {
+        if (pl.any_dora) ntensors++;
+        for (auto& e : pl.chain) ntensors += (size_t)e.scaled + (size_t)e.xs;
+    }
+    ggml_init_params ip = { (ntensors + 8)*ggml_tensor_overhead(), nullptr, true };
+    fl.ctx = ggml_init(ip);
+    for (auto& pl : plans) {
+        if (pl.any_dora) pl.base_scale = ggml_new_tensor_1d(fl.ctx, GGML_TYPE_F32, pl.out);
+        for (auto& e : pl.chain) {
+            const int64_t rank = (int64_t)adapters[e.ai].rank;
+            if (e.scaled) e.Bp   = ggml_new_tensor_2d(fl.ctx, GGML_TYPE_F32, rank, pl.out);
+            if (e.xs)     e.Aeff = ggml_new_tensor_2d(fl.ctx, GGML_TYPE_F32, pl.in, rank);
+        }
+    }
+    fl.buf = ggml_backend_alloc_ctx_tensors(fl.ctx, base.backend);
+
+    // ---- scratch: upload nsq0 (dropped as soon as the row scales are computed) ----
+    ggml_context* sctx = nullptr; ggml_backend_buffer_t sbuf = nullptr;
+    if (need_norms) {
+        ggml_init_params sp = { (plans.size() + 8)*ggml_tensor_overhead(), nullptr, true };
+        sctx = ggml_init(sp);
+        for (auto& pl : plans)
+            if (pl.any_dora) pl.nsq0_t = ggml_new_tensor_1d(sctx, GGML_TYPE_F32, pl.out);
+        sbuf = ggml_backend_alloc_ctx_tensors(sctx, base.backend);
+        for (auto& pl : plans)
+            if (pl.any_dora)
+                ggml_backend_tensor_set(pl.nsq0_t, pl.nsq0.data(), 0, pl.nsq0.size()*sizeof(float));
+    }
+
+    // ---- one-shot precompute, chunked so the graph's scratch stays bounded ----
+    // Deliberately the same op sequence dit_lin's training path uses for the norm reduction, so
+    // the constant folding cannot drift from the reference.
+    size_t maxchain = 1;
+    for (auto& pl : plans) maxchain = std::max(maxchain, pl.chain.size());
+    const size_t per_target = 96 + 64*maxchain + 48*maxchain*maxchain*(1 + maxchain);
+    const size_t chunk = std::max<size_t>(1, 8192 / per_target);
+
+    // coefficient application: v · coef (when coef is a real [out] vector) · f
+    auto coef_mul = [](ggml_context* c, ggml_tensor* v, ggml_tensor* coef, float f) {
+        if (coef) v = ggml_mul(c, v, coef);
+        return f == 1.0f ? v : ggml_scale(c, v, f);
+    };
+
+    for (size_t p0 = 0; p0 < plans.size(); p0 += chunk) {
+        const size_t p1 = std::min(plans.size(), p0 + chunk);
+        const size_t nn = per_target*(p1 - p0) + 64;
         ggml_init_params tp = { nn*ggml_tensor_overhead() + ggml_graph_overhead_custom(nn, false) + (1<<20),
                                 nullptr, true };
-        ggml_context* tctx = ggml_init(tp);
-        ggml_cgraph* gf = ggml_new_graph_custom(tctx, nn, false);
-        size_t si = 0;
-        for (auto& wname : targets) {
-            DitLoraParam& p = fl.map[wname];
-            ggml_tensor* wl  = base.tensors[wname];
-            const int64_t out = wl->ne[1];
-            const float s = p.scale;
-            ggml_tensor* WtA  = ggml_mul_mat(tctx, wl, p.A);                            // [out,rank]
-            ggml_tensor* Bt   = ggml_cont(tctx, ggml_transpose(tctx, p.B));             // [out,rank]
-            ggml_tensor* t2   = ggml_sum_rows(tctx,
-                ggml_cont(tctx, ggml_transpose(tctx, ggml_mul(tctx, WtA, Bt))));        // [1,out]
-            ggml_tensor* AtA  = ggml_mul_mat(tctx, p.A, p.A);                           // [rank,rank]
-            ggml_tensor* AtAB = ggml_mul_mat(tctx, AtA, p.B);                           // [rank,out]
-            ggml_tensor* t3   = ggml_sum_rows(tctx, ggml_mul(tctx, p.B, AtAB));         // [1,out]
-            ggml_tensor* nsq  = ggml_add(tctx,
-                ggml_add(tctx, p.base_norm_sq,
-                               ggml_scale(tctx, ggml_reshape_1d(tctx, t2, out), 2.0f*s)),
-                ggml_scale(tctx, ggml_reshape_1d(tctx, t3, out), s*s));                 // [out]
-            ggml_tensor* sv = ggml_div(tctx, p.magnitude, ggml_sqrt(tctx, nsq));        // [out]
-            ggml_build_forward_expand(gf, ggml_cpy(tctx, sv, scales[si++]));
+        ggml_context* c = ggml_init(tp);
+        ggml_cgraph* gf = ggml_new_graph_custom(c, nn, false);
+
+        for (size_t pi = p0; pi < p1; pi++) {
+            Plan& pl = plans[pi];
+            ggml_tensor* wl = base.tensors[pl.wname];
+            const int64_t out = pl.out;
+            const size_t M = pl.chain.size();
+
+            // A/B per residual. For -xs, regroup U @ M_xs @ Vᵗ into the same B @ A shape; the
+            // computed value (not the persistent copy) is what feeds this graph, so the norm
+            // reduction below depends on it properly.
+            std::vector<ggml_tensor*> A(M), B(M);
+            for (size_t k = 0; k < M; k++) {
+                Entry& e = pl.chain[k];
+                GgufModel& g = adapters[e.ai].gguf;
+                if (e.xs) {
+                    ggml_tensor* MV = ggml_mul_mat(c, g.get(pl.stem+".M_xs"), g.get(pl.stem+".V")); // [rank,in]
+                    A[k] = ggml_cont(c, ggml_transpose(c, MV));                                     // [in,rank]
+                    B[k] = g.get(pl.stem+".U");                                                     // [rank,out]
+                    ggml_build_forward_expand(gf, ggml_cpy(c, A[k], e.Aeff));
+                } else {
+                    A[k] = g.get(pl.stem+".lora_A");
+                    B[k] = g.get(pl.stem+".lora_B");
+                }
+            }
+
+            // Row-space quantities needed by the norms, all low-rank:
+            //   T2[k][o] = W[o,:]·(B_k A_k)[o,:]          via mul_mat(W, A_k) -- W stays quantized
+            //   G[k][l][o] = (B_k A_k)[o,:]·(B_l A_l)[o,:] via the rank x rank gram A_lᵗ A_k
+            std::vector<ggml_tensor*> T2(M, nullptr);
+            std::vector<std::vector<ggml_tensor*>> G(M, std::vector<ggml_tensor*>(M, nullptr));
+            if (pl.any_dora) {
+                for (size_t k = 0; k < M; k++) {
+                    ggml_tensor* WtA = ggml_mul_mat(c, wl, A[k]);                     // [out,rank]
+                    ggml_tensor* Bt  = ggml_cont(c, ggml_transpose(c, B[k]));         // [out,rank]
+                    T2[k] = ggml_reshape_1d(c, ggml_sum_rows(c,
+                        ggml_cont(c, ggml_transpose(c, ggml_mul(c, WtA, Bt)))), out);  // [out]
+                }
+                for (size_t k = 0; k < M; k++) for (size_t l = k; l < M; l++) {
+                    ggml_tensor* gram = ggml_mul_mat(c, A[l], A[k]);                  // [rank_l,rank_k]
+                    ggml_tensor* GB   = ggml_mul_mat(c, gram, B[l]);                   // [rank_k,out]
+                    G[k][l] = ggml_reshape_1d(c, ggml_sum_rows(c, ggml_mul(c, B[k], GB)), out);
+                    G[l][k] = G[k][l];
+                }
+            }
+
+            // Walk the chain. b is the base coefficient, g[k] the coefficient on residual k;
+            // null means 1.0, which keeps the single-adapter case emitting the same handful of
+            // ops the dedicated row_scale path used to.
+            ggml_tensor* b = nullptr;
+            std::vector<ggml_tensor*> g(M, nullptr);
+            for (size_t j = 0; j < M; j++) {
+                if (!pl.chain[j].dora) continue;
+                // ||V_j row o||² = b²·nsq0 + 2b·Σ_k h_k·T2_k + Σ_{k,l} h_k·h_l·G_kl, h_k = s_k·g_k,
+                // over the adapters present so far. (The in·eps regulariser baked into nsq0 gets
+                // carried along by b² rather than re-added; ~1e-12 relative, far below f16.)
+                ggml_tensor* nsq = b ? ggml_mul(c, pl.nsq0_t, ggml_mul(c, b, b)) : pl.nsq0_t;
+                for (size_t k = 0; k <= j; k++) {
+                    ggml_tensor* t = coef_mul(c, T2[k], g[k], 2.0f*pl.chain[k].scale);
+                    if (b) t = ggml_mul(c, t, b);
+                    nsq = ggml_add(c, nsq, t);
+                }
+                for (size_t k = 0; k <= j; k++) for (size_t l = k; l <= j; l++) {
+                    const float sc = pl.chain[k].scale*pl.chain[l].scale*(k == l ? 1.0f : 2.0f);
+                    ggml_tensor* t = coef_mul(c, G[k][l], g[k], sc);
+                    if (g[l]) t = ggml_mul(c, t, g[l]);
+                    nsq = ggml_add(c, nsq, t);
+                }
+                ggml_tensor* mag = adapters[pl.chain[j].ai].gguf.get(pl.stem + ".magnitude");
+                ggml_tensor* d   = ggml_div(c, mag, ggml_sqrt(c, nsq));               // [out]
+                b = b ? ggml_mul(c, b, d) : d;
+                for (size_t k = 0; k <= j; k++) g[k] = g[k] ? ggml_mul(c, g[k], d) : d;
+            }
+
+            if (pl.base_scale) ggml_build_forward_expand(gf, ggml_cpy(c, b, pl.base_scale));
+            for (size_t k = 0; k < M; k++) {
+                Entry& e = pl.chain[k];
+                if (!e.Bp) continue;                     // coefficient 1 -> dit_lin reads B directly
+                ggml_tensor* Bf = B[k]->type == GGML_TYPE_F32 ? B[k] : ggml_cast(c, B[k], GGML_TYPE_F32);
+                ggml_build_forward_expand(gf, ggml_cpy(c,
+                    ggml_mul(c, Bf, ggml_reshape_2d(c, g[k], 1, out)), e.Bp));  // broadcast over rank
+            }
         }
+
         ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(base.backend));
         ggml_gallocr_alloc_graph(alloc, gf);
         ggml_backend_graph_compute(base.backend, gf);
         ggml_gallocr_free(alloc);
-        ggml_free(tctx);
+        ggml_free(c);
+    }
+
+    if (sbuf) ggml_backend_buffer_free(sbuf);
+    if (sctx) ggml_free(sctx);
+
+    // ---- publish the per-target term lists dit_lin will walk ----
+    for (auto& pl : plans) {
+        DitLoraParam p;
+        p.base_scale = pl.base_scale;
+        p.in = pl.in;
+        for (auto& e : pl.chain) {
+            GgufModel& g = adapters[e.ai].gguf;
+            DitLoraTerm t;
+            t.A     = e.xs ? e.Aeff : g.get(pl.stem + ".lora_A");
+            t.B     = e.Bp ? e.Bp   : g.get(pl.stem + (e.xs ? ".U" : ".lora_B"));
+            t.scale = e.scale;
+            p.terms.push_back(t);
+        }
+        fl.map[pl.wname] = p;
     }
     fl.active = true;
     return fl;

--- a/src/lora.h
+++ b/src/lora.h
@@ -16,8 +16,13 @@
 #include "gguf_model.h"
 
 #include <cmath>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <map>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <vector>
 
 namespace sa3 {
@@ -259,6 +264,75 @@ struct FunctionalLora {
     }
 };
 
+// base_norm_sq depends only on the base weights, never on the adapter, so it is the same for
+// every LoRA ever loaded against a given model. Computing it means pulling every targeted
+// weight to the host and summing squares, which costs seconds; cache it in a sidecar next to
+// the gguf so only the first run pays. Keyed on the model's byte size, which changes for any
+// re-conversion or re-quantization.
+namespace normcache {
+
+inline std::string path_for(const std::string& model_path) { return model_path + ".norms"; }
+
+inline bool load(const std::string& model_path, std::map<std::string, std::vector<float>>& out) {
+    std::error_code ec;
+    const uintmax_t model_sz = std::filesystem::file_size(model_path, ec);
+    if (ec) return false;
+    std::ifstream f(path_for(model_path), std::ios::binary);
+    if (!f) return false;
+    char magic[8] = {0};
+    uint64_t src_sz = 0, n = 0;
+    f.read(magic, 8);
+    if (std::memcmp(magic, "SA3NORM1", 8) != 0) return false;
+    f.read((char*)&src_sz, 8);
+    if (!f || src_sz != (uint64_t)model_sz) return false;      // model changed -> recompute
+    f.read((char*)&n, 8);
+    if (!f || n > (1u << 20)) return false;
+    for (uint64_t i = 0; i < n; i++) {
+        uint32_t nl = 0; uint64_t cnt = 0;
+        f.read((char*)&nl, 4);
+        if (!f || nl == 0 || nl > 512) return false;
+        std::string name(nl, '\0');
+        f.read(&name[0], nl);
+        f.read((char*)&cnt, 8);
+        if (!f || cnt == 0 || cnt > (1u << 24)) return false;
+        std::vector<float> v(cnt);
+        f.read((char*)v.data(), (std::streamsize)(cnt*sizeof(float)));
+        if (!f) return false;
+        out[name] = std::move(v);
+    }
+    return true;
+}
+
+inline void save(const std::string& model_path, const std::map<std::string, std::vector<float>>& in) {
+    std::error_code ec;
+    const uintmax_t model_sz = std::filesystem::file_size(model_path, ec);
+    if (ec) return;
+    // Write to a temp then rename, so a killed run cannot leave a half-written cache that
+    // would later be read as valid.
+    const std::string tmp = path_for(model_path) + ".tmp";
+    {
+        std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+        if (!f) return;
+        const uint64_t src_sz = (uint64_t)model_sz, n = in.size();
+        f.write("SA3NORM1", 8);
+        f.write((const char*)&src_sz, 8);
+        f.write((const char*)&n, 8);
+        for (auto& kv : in) {
+            const uint32_t nl = (uint32_t)kv.first.size();
+            const uint64_t cnt = kv.second.size();
+            f.write((const char*)&nl, 4);
+            f.write(kv.first.data(), nl);
+            f.write((const char*)&cnt, 8);
+            f.write((const char*)kv.second.data(), (std::streamsize)(cnt*sizeof(float)));
+        }
+        if (!f) { f.close(); std::filesystem::remove(tmp, ec); return; }
+    }
+    std::filesystem::rename(tmp, path_for(model_path), ec);
+    if (ec) std::filesystem::remove(tmp, ec);
+}
+
+} // namespace normcache
+
 inline bool functional_lora_ok(const std::vector<LoraAdapter>& adapters) {
     if (adapters.size() != 1) return false;
     const std::string& t = adapters[0].type;
@@ -268,11 +342,16 @@ inline bool functional_lora_ok(const std::vector<LoraAdapter>& adapters) {
 // Build the dit_lin adapter map for `adapters[0]` over `base`. Adapter tensors must already
 // live on base.backend (load_lora(..., base.backend)); only the dora-rows base_norm_sq
 // constants are allocated here, computed on the host from W (quantized W included).
-inline FunctionalLora build_functional_lora(GgufModel& base, std::vector<LoraAdapter>& adapters) {
+inline FunctionalLora build_functional_lora(GgufModel& base, std::vector<LoraAdapter>& adapters,
+                                            const std::string& base_path = "") {
     FunctionalLora fl;
     if (!functional_lora_ok(adapters)) return fl;
     LoraAdapter& a = adapters[0];
     const bool dora = (a.type == "dora-rows");
+
+    std::map<std::string, std::vector<float>> nsq_cache;
+    bool cache_hit = false, cache_dirty = false;
+    if (dora && !base_path.empty()) cache_hit = normcache::load(base_path, nsq_cache);
 
     std::vector<std::string> targets;
     for (auto& kv : base.tensors) {
@@ -302,14 +381,23 @@ inline FunctionalLora build_functional_lora(GgufModel& base, std::vector<LoraAda
             p.magnitude = a.gguf.get(stem + ".magnitude");
             // base_norm_sq[o] = Σ_in W[o,i]² + in·eps, matching train_row_norm_sq. Reading W
             // here is the one place the base is touched outside a matmul, and read_to_f32
-            // dequantizes on the host, so it is fine for a quantized base.
-            std::vector<float> w;  read_to_f32(W0, w);
-            std::vector<float> nsq((size_t)out, 0.0f);
-            for (int64_t o = 0; o < out; o++) {
-                double s = 0.0;
-                const float* wo = &w[(size_t)o*in];
-                for (int64_t i = 0; i < in; i++) s += (double)wo[i]*wo[i];
-                nsq[(size_t)o] = (float)(s + (double)in * 1e-12);
+            // dequantizes on the host, so it is fine for a quantized base. It is also the
+            // expensive part, hence the sidecar cache.
+            std::vector<float> nsq;
+            auto it = nsq_cache.find(wname);
+            if (it != nsq_cache.end() && it->second.size() == (size_t)out) {
+                nsq = it->second;
+            } else {
+                std::vector<float> w;  read_to_f32(W0, w);
+                nsq.assign((size_t)out, 0.0f);
+                for (int64_t o = 0; o < out; o++) {
+                    double s = 0.0;
+                    const float* wo = &w[(size_t)o*in];
+                    for (int64_t i = 0; i < in; i++) s += (double)wo[i]*wo[i];
+                    nsq[(size_t)o] = (float)(s + (double)in * 1e-12);
+                }
+                nsq_cache[wname] = nsq;
+                cache_dirty = true;
             }
             ggml_tensor* nt = ggml_new_tensor_1d(fl.ctx, GGML_TYPE_F32, out);
             ggml_tensor* st = ggml_new_tensor_1d(fl.ctx, GGML_TYPE_F32, out);
@@ -322,6 +410,12 @@ inline FunctionalLora build_functional_lora(GgufModel& base, std::vector<LoraAda
     fl.buf = ggml_backend_alloc_ctx_tensors(fl.ctx, base.backend);
     for (size_t i = 0; i < norms.size(); i++)
         ggml_backend_tensor_set(norms[i], norm_host[i].data(), 0, norm_host[i].size()*sizeof(float));
+    if (cache_dirty && !base_path.empty()) {
+        normcache::save(base_path, nsq_cache);
+        printf("lora: wrote base-norm cache %s\n", normcache::path_for(base_path).c_str());
+    } else if (cache_hit) {
+        printf("lora: base-norm cache hit (%zu tensors)\n", nsq_cache.size());
+    }
 
     // Fill row_scale once. Deliberately the same op sequence dit_lin uses for the per-step
     // path, so the shortcut cannot drift from the reference: nsq = base_norm_sq + 2s·t2 + s²·t3,

--- a/src/lora.h
+++ b/src/lora.h
@@ -282,10 +282,11 @@ inline FunctionalLora build_functional_lora(GgufModel& base, std::vector<LoraAda
     }
     if (targets.empty()) return fl;
 
-    // One f32 [out] constant per dora-rows target.
-    ggml_init_params ip = { (targets.size()+2)*ggml_tensor_overhead(), nullptr, true };
+    // Two persistent f32 [out] constants per dora-rows target: base_norm_sq (host-computed)
+    // and row_scale (filled by the one-shot graph below).
+    ggml_init_params ip = { (2*targets.size()+4)*ggml_tensor_overhead(), nullptr, true };
     fl.ctx = ggml_init(ip);
-    std::vector<ggml_tensor*> norms;
+    std::vector<ggml_tensor*> norms, scales;
     std::vector<std::vector<float>> norm_host;
     for (auto& wname : targets) {
         ggml_tensor* W0 = base.tensors[wname];
@@ -310,16 +311,53 @@ inline FunctionalLora build_functional_lora(GgufModel& base, std::vector<LoraAda
                 for (int64_t i = 0; i < in; i++) s += (double)wo[i]*wo[i];
                 nsq[(size_t)o] = (float)(s + (double)in * 1e-12);
             }
-            ggml_tensor* t = ggml_new_tensor_1d(fl.ctx, GGML_TYPE_F32, out);
-            norms.push_back(t); norm_host.push_back(std::move(nsq));
-            p.base_norm_sq = t;
+            ggml_tensor* nt = ggml_new_tensor_1d(fl.ctx, GGML_TYPE_F32, out);
+            ggml_tensor* st = ggml_new_tensor_1d(fl.ctx, GGML_TYPE_F32, out);
+            norms.push_back(nt); scales.push_back(st); norm_host.push_back(std::move(nsq));
+            p.base_norm_sq = nt;
+            p.row_scale    = st;
         }
         fl.map[wname] = p;
     }
-    if (!norms.empty()) {
-        fl.buf = ggml_backend_alloc_ctx_tensors(fl.ctx, base.backend);
-        for (size_t i = 0; i < norms.size(); i++)
-            ggml_backend_tensor_set(norms[i], norm_host[i].data(), 0, norm_host[i].size()*sizeof(float));
+    fl.buf = ggml_backend_alloc_ctx_tensors(fl.ctx, base.backend);
+    for (size_t i = 0; i < norms.size(); i++)
+        ggml_backend_tensor_set(norms[i], norm_host[i].data(), 0, norm_host[i].size()*sizeof(float));
+
+    // Fill row_scale once. Deliberately the same op sequence dit_lin uses for the per-step
+    // path, so the shortcut cannot drift from the reference: nsq = base_norm_sq + 2s·t2 + s²·t3,
+    // row_scale = magnitude / sqrt(nsq). Every input here is frozen at inference, which is why
+    // this is a constant rather than per-step work.
+    if (!scales.empty()) {
+        const size_t nn = targets.size()*24 + 64;
+        ggml_init_params tp = { nn*ggml_tensor_overhead() + ggml_graph_overhead_custom(nn, false) + (1<<20),
+                                nullptr, true };
+        ggml_context* tctx = ggml_init(tp);
+        ggml_cgraph* gf = ggml_new_graph_custom(tctx, nn, false);
+        size_t si = 0;
+        for (auto& wname : targets) {
+            DitLoraParam& p = fl.map[wname];
+            ggml_tensor* wl  = base.tensors[wname];
+            const int64_t out = wl->ne[1];
+            const float s = p.scale;
+            ggml_tensor* WtA  = ggml_mul_mat(tctx, wl, p.A);                            // [out,rank]
+            ggml_tensor* Bt   = ggml_cont(tctx, ggml_transpose(tctx, p.B));             // [out,rank]
+            ggml_tensor* t2   = ggml_sum_rows(tctx,
+                ggml_cont(tctx, ggml_transpose(tctx, ggml_mul(tctx, WtA, Bt))));        // [1,out]
+            ggml_tensor* AtA  = ggml_mul_mat(tctx, p.A, p.A);                           // [rank,rank]
+            ggml_tensor* AtAB = ggml_mul_mat(tctx, AtA, p.B);                           // [rank,out]
+            ggml_tensor* t3   = ggml_sum_rows(tctx, ggml_mul(tctx, p.B, AtAB));         // [1,out]
+            ggml_tensor* nsq  = ggml_add(tctx,
+                ggml_add(tctx, p.base_norm_sq,
+                               ggml_scale(tctx, ggml_reshape_1d(tctx, t2, out), 2.0f*s)),
+                ggml_scale(tctx, ggml_reshape_1d(tctx, t3, out), s*s));                 // [out]
+            ggml_tensor* sv = ggml_div(tctx, p.magnitude, ggml_sqrt(tctx, nsq));        // [out]
+            ggml_build_forward_expand(gf, ggml_cpy(tctx, sv, scales[si++]));
+        }
+        ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(base.backend));
+        ggml_gallocr_alloc_graph(alloc, gf);
+        ggml_backend_graph_compute(base.backend, gf);
+        ggml_gallocr_free(alloc);
+        ggml_free(tctx);
     }
     fl.active = true;
     return fl;

--- a/src/lora.h
+++ b/src/lora.h
@@ -41,7 +41,7 @@ inline LoraAdapter load_lora(const char* path, float strength = 1.0f, ggml_backe
     return a;
 }
 
-// Read any tensor (F32 or F16) into an F32 host buffer.
+// Read any tensor (F32, F16, or a quantized type) into an F32 host buffer.
 inline void read_to_f32(ggml_tensor* t, std::vector<float>& dst) {
     const int64_t n = ggml_nelements(t);
     dst.resize(n);
@@ -49,6 +49,18 @@ inline void read_to_f32(ggml_tensor* t, std::vector<float>& dst) {
         std::vector<ggml_fp16_t> tmp(n);
         ggml_backend_tensor_get(t, tmp.data(), 0, n*sizeof(ggml_fp16_t));
         ggml_fp16_to_fp32_row(tmp.data(), dst.data(), n);
+    } else if (ggml_is_quantized(t->type)) {
+        // Pull the packed bytes down and unpack with the type's own reference dequantizer.
+        // Asking ggml_backend_tensor_get for n floats would over-read the tensor (a Q4_K row
+        // is ~0.56 bytes/element) and trip its bounds assert.
+        const size_t nbytes = ggml_nbytes(t);
+        std::vector<char> raw(nbytes);
+        ggml_backend_tensor_get(t, raw.data(), 0, nbytes);
+        const ggml_type_traits* tr = ggml_get_type_traits(t->type);
+        const int64_t ne0 = t->ne[0], rows = n / ne0;
+        const size_t row_bytes = ggml_row_size(t->type, ne0);
+        for (int64_t r = 0; r < rows; r++)
+            tr->to_float(raw.data() + (size_t)r*row_bytes, dst.data() + r*ne0, ne0);
     } else {
         ggml_backend_tensor_get(t, dst.data(), 0, n*sizeof(float));
     }
@@ -215,6 +227,102 @@ inline LoraStack apply_loras(GgufModel& base, std::vector<LoraAdapter>& adapters
     }
     return lora_graph_ok(adapters) ? apply_loras_graph(base, adapters, targets)
                                    : apply_loras_host(base, adapters, targets);
+}
+
+// ---------------------------------------------------------------------------------------
+// Functional (graph-time) adapters — the path that works over a QUANTIZED base.
+//
+// apply_loras above rewrites W in place, which needs to read W out and write W_eff back.
+// Neither has a route for k-quant types: the graph path dies in ggml_cast (no q6_K->f32 cpy)
+// and the host path cannot re-pack an f32 result into Q4_K storage. So a quantized base
+// fundamentally cannot carry a merged adapter.
+//
+// Instead hand the adapter tensors to dit_lin (src/dit.h), which folds them into the graph:
+//     y = W@x + scale·B@(A@x)                                    [+ dora row scale]
+// W is only ever an argument to mul_mat, and quantized mul_mat is supported on every
+// backend, so the base never has to be dequantized or rewritten. This is the same
+// formulation the training graph already uses; inference simply passed dl = nullptr.
+//
+// Limits (both fall back to the merge path):
+//   - one adapter at a time. DitLoraParam holds a single A/B per target, and DoRA does not
+//     commute, so composing several functionally is not a matter of summing them.
+//   - "lora" and "dora-rows" only, matching what dit_lin implements.
+struct FunctionalLora {
+    DitLora               map;
+    ggml_context*         ctx = nullptr;   // owns the base_norm_sq constants
+    ggml_backend_buffer_t buf = nullptr;
+    bool active = false;
+    void free() {
+        if (buf) ggml_backend_buffer_free(buf);
+        if (ctx) ggml_free(ctx);
+        ctx = nullptr; buf = nullptr; map.clear(); active = false;
+    }
+};
+
+inline bool functional_lora_ok(const std::vector<LoraAdapter>& adapters) {
+    if (adapters.size() != 1) return false;
+    const std::string& t = adapters[0].type;
+    return t == "lora" || t == "dora-rows";
+}
+
+// Build the dit_lin adapter map for `adapters[0]` over `base`. Adapter tensors must already
+// live on base.backend (load_lora(..., base.backend)); only the dora-rows base_norm_sq
+// constants are allocated here, computed on the host from W (quantized W included).
+inline FunctionalLora build_functional_lora(GgufModel& base, std::vector<LoraAdapter>& adapters) {
+    FunctionalLora fl;
+    if (!functional_lora_ok(adapters)) return fl;
+    LoraAdapter& a = adapters[0];
+    const bool dora = (a.type == "dora-rows");
+
+    std::vector<std::string> targets;
+    for (auto& kv : base.tensors) {
+        const std::string& wname = kv.first;
+        if (wname.size() < 7 || wname.compare(wname.size()-7, 7, ".weight") != 0) continue;
+        if (a.gguf.has(wname.substr(0, wname.size()-7) + ".lora_A")) targets.push_back(wname);
+    }
+    if (targets.empty()) return fl;
+
+    // One f32 [out] constant per dora-rows target.
+    ggml_init_params ip = { (targets.size()+2)*ggml_tensor_overhead(), nullptr, true };
+    fl.ctx = ggml_init(ip);
+    std::vector<ggml_tensor*> norms;
+    std::vector<std::vector<float>> norm_host;
+    for (auto& wname : targets) {
+        ggml_tensor* W0 = base.tensors[wname];
+        const int64_t in = W0->ne[0], out = W0->ne[1];
+        std::string stem = wname.substr(0, wname.size()-7);
+        DitLoraParam p;
+        p.A     = a.gguf.get(stem + ".lora_A");
+        p.B     = a.gguf.get(stem + ".lora_B");
+        p.scale = (a.alpha / a.rank) * a.strength;
+        p.dora  = dora;
+        p.in    = in;
+        if (dora) {
+            p.magnitude = a.gguf.get(stem + ".magnitude");
+            // base_norm_sq[o] = Σ_in W[o,i]² + in·eps, matching train_row_norm_sq. Reading W
+            // here is the one place the base is touched outside a matmul, and read_to_f32
+            // dequantizes on the host, so it is fine for a quantized base.
+            std::vector<float> w;  read_to_f32(W0, w);
+            std::vector<float> nsq((size_t)out, 0.0f);
+            for (int64_t o = 0; o < out; o++) {
+                double s = 0.0;
+                const float* wo = &w[(size_t)o*in];
+                for (int64_t i = 0; i < in; i++) s += (double)wo[i]*wo[i];
+                nsq[(size_t)o] = (float)(s + (double)in * 1e-12);
+            }
+            ggml_tensor* t = ggml_new_tensor_1d(fl.ctx, GGML_TYPE_F32, out);
+            norms.push_back(t); norm_host.push_back(std::move(nsq));
+            p.base_norm_sq = t;
+        }
+        fl.map[wname] = p;
+    }
+    if (!norms.empty()) {
+        fl.buf = ggml_backend_alloc_ctx_tensors(fl.ctx, base.backend);
+        for (size_t i = 0; i < norms.size(); i++)
+            ggml_backend_tensor_set(norms[i], norm_host[i].data(), 0, norm_host[i].size()*sizeof(float));
+    }
+    fl.active = true;
+    return fl;
 }
 
 } // namespace sa3

--- a/src/sa3_pipeline.h
+++ b/src/sa3_pipeline.h
@@ -997,7 +997,7 @@ inline GenResult Pipeline::generate(const GenParams& params) {
             const bool quantized = dit_base_is_quantized(DIT);
             const bool want_functional = quantized || getenv("SA3_FUNCTIONAL_LORA");
             if (want_functional && sa3::functional_lora_ok(dit_adapters_)) {
-                dit_functional_ = sa3::build_functional_lora(DIT, dit_adapters_);
+                dit_functional_ = sa3::build_functional_lora(DIT, dit_adapters_, paths_.dit);
             }
             if (!dit_functional_.active) {
                 if (quantized)

--- a/src/sa3_pipeline.h
+++ b/src/sa3_pipeline.h
@@ -286,6 +286,17 @@ struct ModelPaths {
                         const std::string& encoding, ModelPaths& out, std::string& err);
 };
 
+// True if the DiT's projection weights are stored as a quantized type. Checked on a weight
+// the adapters actually target, since norms/biases stay F32 in every encoding.
+inline bool dit_base_is_quantized(const GgufModel& dit) {
+    for (auto& kv : dit.tensors) {
+        const std::string& n = kv.first;
+        if (n.size() >= 7 && n.compare(n.size()-7, 7, ".weight") == 0 && kv.second->ne[1] > 1)
+            if (ggml_is_quantized(kv.second->type)) return true;
+    }
+    return false;
+}
+
 // Canonical file-suffix label for an --encoding value, or "" if unrecognised.
 // Suffixes follow the Encoding field in docs/DISTRIBUTION.md (gguf-spec naming, same
 // spelling llama.cpp uses): Q4_K_M / Q5_K_M, not Q4_KM. The compact spellings are
@@ -481,7 +492,10 @@ private:
     Tokenizer tok_;
     GgufModel TE_, DIT_, AE_;
     std::unique_ptr<GgufModel> CD_;    // per-variant conditioner sidecar, or null => use TE_
-    std::vector<std::pair<std::string,float>> dit_loras_;  // adapters currently baked into the live DiT (in-place)
+    std::vector<std::pair<std::string,float>> dit_loras_;  // adapters currently applied to the live DiT
+    bool dit_merged_ = false;                  // true => dit_loras_ were baked into DIT_ in place
+    std::vector<LoraAdapter> dit_adapters_;    // kept resident for the functional path (graph reads A/B)
+    FunctionalLora dit_functional_;            // graph-time adapters; empty unless the functional path is used
     T5GemmaConfig tc_{};
     DitConfig     dc_{};
     SameConfig    sc_{};
@@ -966,19 +980,38 @@ inline GenResult Pipeline::generate(const GenParams& params) {
     // adapters skip the work; a change pays a reload).
     if (dit_loras_ != params.loras) {
         throw_if_cancelled(params.should_cancel);
-        if (!dit_loras_.empty()) {           // DiT carries a prior request's adapters -> reload a clean base
+        if (dit_merged_) {                   // prior request BAKED adapters in -> reload a clean base
             DIT.free();
             DIT_ = load_gguf(paths_.dit.c_str(), backend_);
-            dit_loras_.clear();
+            dit_merged_ = false;
         }
+        dit_functional_.free();              // functional adapters leave the base untouched
+        dit_adapters_.clear();
+        dit_loras_.clear();
         if (!params.loras.empty()) {
-            std::vector<sa3::LoraAdapter> adapters;
-            for (auto& ls : params.loras) adapters.push_back(sa3::load_lora(ls.first.c_str(), ls.second, DIT.backend));
-            sa3::apply_loras(DIT, adapters);
-            printf("lora: applied %zu adapter(s):\n", adapters.size());
-            for (size_t i = 0; i < adapters.size(); i++)
-                printf("  [%zu] %s  type=%s strength=%.2f\n", i, params.loras[i].first.c_str(),
-                       adapters[i].type.c_str(), adapters[i].strength);
+            for (auto& ls : params.loras) dit_adapters_.push_back(sa3::load_lora(ls.first.c_str(), ls.second, DIT.backend));
+            // A quantized base can only take the functional path: merging would have to read W
+            // out and write W_eff back, and neither has a route for k-quant types. On an f16/f32
+            // base the merge is still the default (it costs nothing per step); SA3_FUNCTIONAL_LORA
+            // forces the functional path there too, for A/B against the merged reference.
+            const bool quantized = dit_base_is_quantized(DIT);
+            const bool want_functional = quantized || getenv("SA3_FUNCTIONAL_LORA");
+            if (want_functional && sa3::functional_lora_ok(dit_adapters_)) {
+                dit_functional_ = sa3::build_functional_lora(DIT, dit_adapters_);
+            }
+            if (!dit_functional_.active) {
+                if (quantized)
+                    throw std::runtime_error(
+                        "lora: a quantized DiT (--encoding q4_k_m/q5_k_m/q8_0) supports one "
+                        "'lora' or 'dora-rows' adapter at a time; use --encoding f16 for this set");
+                sa3::apply_loras(DIT, dit_adapters_);
+                dit_merged_ = true;
+                dit_adapters_.clear();       // merged into W; nothing to keep resident
+            }
+            printf("lora: applied %zu adapter(s) [%s]:\n", params.loras.size(),
+                   dit_functional_.active ? "functional" : "merged");
+            for (size_t i = 0; i < params.loras.size(); i++)
+                printf("  [%zu] %s  strength=%.2f\n", i, params.loras[i].first.c_str(), params.loras[i].second);
         }
         dit_loras_ = params.loras;
         if (params.should_cancel && params.should_cancel())
@@ -1000,7 +1033,8 @@ inline GenResult Pipeline::generate(const GenParams& params) {
     for (ggml_tensor* t : {x_in, tfeat, cross, glob, pos_d, ones}) ggml_set_input(t);
     ggml_tensor* local = nullptr;
     if (!localb.empty()) { local = ggml_new_tensor_2d(dctx, GGML_TYPE_F32, dc.local_dim, T); ggml_set_input(local); }
-    ggml_tensor* vel = ggml_cont(dctx, sa3::dit_forward(dctx, DIT, x_in, tfeat, cross, glob, pos_d, ones, dc, local));
+    ggml_tensor* vel = ggml_cont(dctx, sa3::dit_forward(dctx, DIT, x_in, tfeat, cross, glob, pos_d, ones, dc, local,
+                                                    dit_functional_.active ? &dit_functional_.map : nullptr));
     ggml_set_output(vel);
     ggml_cgraph* gf_dit = ggml_new_graph_custom(dctx, 32768, false);
     ggml_build_forward_expand(gf_dit, vel);
@@ -1072,7 +1106,8 @@ inline GenResult Pipeline::generate(const GenParams& params) {
     profile_log(prof, "dit_get_update", dit_download_update);
     profile_log(prof, "dit_total", wall_time_s() - t_dit_total);
     ggml_gallocr_free(alloc_dit); ggml_free(dctx);
-    if (!keep_models) { DIT.free(); dit_loras_.clear(); }   // DiT gone -> next gen reloads a clean base
+    if (!keep_models) { DIT.free(); dit_loras_.clear(); dit_merged_ = false;
+                       dit_functional_.free(); dit_adapters_.clear(); }   // DiT gone -> next gen reloads a clean base
     if (dit_cancelled)
         throw_cancelled_after_frugal_cleanup();
 

--- a/src/sa3_pipeline.h
+++ b/src/sa3_pipeline.h
@@ -995,15 +995,17 @@ inline GenResult Pipeline::generate(const GenParams& params) {
             // base the merge is still the default (it costs nothing per step); SA3_FUNCTIONAL_LORA
             // forces the functional path there too, for A/B against the merged reference.
             const bool quantized = dit_base_is_quantized(DIT);
-            const bool want_functional = quantized || getenv("SA3_FUNCTIONAL_LORA");
+            const char* fenv = getenv("SA3_FUNCTIONAL_LORA");
+            const bool want_functional = quantized || (fenv && strcmp(fenv, "0") != 0);
             if (want_functional && sa3::functional_lora_ok(dit_adapters_)) {
                 dit_functional_ = sa3::build_functional_lora(DIT, dit_adapters_, paths_.dit);
             }
             if (!dit_functional_.active) {
                 if (quantized)
                     throw std::runtime_error(
-                        "lora: a quantized DiT (--encoding q4_k_m/q5_k_m/q8_0) supports one "
-                        "'lora' or 'dora-rows' adapter at a time; use --encoding f16 for this set");
+                        "lora: a quantized DiT (--encoding q4_k_m/q5_k_m/q8_0) supports the "
+                        "'lora' and 'dora-rows' families (including -xs), any number of them; "
+                        "'dora-cols'/'bora' must be merged, so use --encoding f16 for this set");
                 sa3::apply_loras(DIT, dit_adapters_);
                 dit_merged_ = true;
                 dit_adapters_.clear();       // merged into W; nothing to keep resident

--- a/tests/lora_compose_test.cpp
+++ b/tests/lora_compose_test.cpp
@@ -1,0 +1,284 @@
+// lora_compose_test: build_functional_lora must compose a chain of adapters to exactly what
+// sequentially merging them produces. The reference here is the real merge path (apply_loras,
+// which rewrites W_eff in place, each adapter reading the previous one's result) rather than a
+// reimplementation of it, so the test pins the two paths to each other rather than to my algebra.
+//
+// The composed form under test (see DitLoraParam::terms) is
+//     y = c_0 ⊙ (W@x) + Σ_k s_k · c_k ⊙ (B_k @ (A_k @ x)),
+// with c_0 = Π_{dora j} d_j and c_k = Π_{dora j >= k} d_j. Since a later dora rescales earlier
+// residuals, order matters, and the last case below checks it actually does.
+#include "lora.h"
+#include "test_backend.h"
+
+#include <cmath>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+
+static int fails = 0;
+
+static void expect(bool ok, const std::string& msg) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", msg.c_str()); fails++; }
+}
+
+// ---- in-memory GgufModel construction (no file, no gguf metadata: apply_loras and
+// build_functional_lora both read rank/alpha/strength off LoraAdapter, not off the gguf) ----
+struct TensorSpec { std::string name; int64_t ne0 = 0, ne1 = 1; std::vector<float> data; };
+
+static void build_model(sa3::GgufModel& m, const std::vector<TensorSpec>& specs) {
+    ggml_init_params ip = { (specs.size() + 4) * ggml_tensor_overhead(), nullptr, true };
+    m.ctx = ggml_init(ip);
+    m.backend = sa3_test_cpu_backend();
+    m.owns_backend = false;                        // the CPU backend is shared and static
+    for (const auto& s : specs) {
+        ggml_tensor* t = ggml_new_tensor_2d(m.ctx, GGML_TYPE_F32, s.ne0, s.ne1);
+        ggml_set_name(t, s.name.c_str());
+        m.tensors[s.name] = t;
+    }
+    m.buf = ggml_backend_alloc_ctx_tensors(m.ctx, m.backend);
+    for (const auto& s : specs)
+        ggml_backend_tensor_set(m.tensors[s.name], s.data.data(), 0, s.data.size() * sizeof(float));
+}
+
+// The DiT weights this test adapts. `in`/`out` differ per target, and `solo` is targeted by only
+// one adapter so the per-target chain really is per-target.
+struct Target { std::string stem; int64_t in, out; };
+static const std::vector<Target> kTargets = {
+    { "dit.0.self.qkv", 8, 6 },
+    { "dit.0.ff.up",    6, 10 },
+    { "dit.1.self.out", 10, 4 },   // the "solo" target
+};
+
+struct AdapterSpec {
+    std::string type;
+    int rank = 2;
+    float alpha = 4.0f, strength = 1.0f;
+    bool skip_solo = false;        // leave dit.1.self.out untargeted
+};
+
+int main() {
+    std::mt19937 rng(20260730);
+    std::normal_distribution<float> nd(0.0f, 0.5f);
+    const int64_t SEQ = 5;
+
+    // ---- the shared base weights, generated once and reused by every case ----
+    std::vector<TensorSpec> base_specs;
+    for (const auto& t : kTargets) {
+        TensorSpec s{ t.stem + ".weight", t.in, t.out, {} };
+        s.data.resize((size_t)t.in * t.out);
+        for (auto& v : s.data) v = nd(rng);
+        base_specs.push_back(std::move(s));
+    }
+    // activations, one per distinct input width
+    std::vector<std::vector<float>> xs;
+    for (const auto& t : kTargets) {
+        std::vector<float> v((size_t)t.in * SEQ);
+        for (auto& e : v) e = nd(rng);
+        xs.push_back(std::move(v));
+    }
+
+    // ---- adapter tensor data, generated once per (spec index, target) so the merge and the
+    // functional path see bit-identical adapters ----
+    auto make_adapter_specs = [&](const AdapterSpec& as, uint32_t seed) {
+        std::vector<TensorSpec> out;
+        std::mt19937 r(seed);
+        std::normal_distribution<float> n(0.0f, 0.4f);
+        const bool xs_fam = sa3::functional_lora_is_xs(as.type);
+        for (const auto& t : kTargets) {
+            if (as.skip_solo && t.stem == "dit.1.self.out") continue;
+            const int64_t rk = as.rank;
+            if (xs_fam) {
+                // U [rank,out], V [rank,in], M_xs [rank,rank] -- delta = U @ M_xs @ Vᵗ
+                TensorSpec U{ t.stem + ".U", rk, t.out, {} };  U.data.resize((size_t)rk * t.out);
+                TensorSpec V{ t.stem + ".V", rk, t.in,  {} };  V.data.resize((size_t)rk * t.in);
+                TensorSpec M{ t.stem + ".M_xs", rk, rk, {} };  M.data.resize((size_t)rk * rk);
+                for (auto& v : U.data) v = n(r);
+                for (auto& v : V.data) v = n(r);
+                for (auto& v : M.data) v = n(r);
+                out.push_back(std::move(U)); out.push_back(std::move(V)); out.push_back(std::move(M));
+            } else {
+                TensorSpec A{ t.stem + ".lora_A", t.in, rk, {} };  A.data.resize((size_t)t.in * rk);
+                TensorSpec B{ t.stem + ".lora_B", rk, t.out, {} }; B.data.resize((size_t)rk * t.out);
+                for (auto& v : A.data) v = n(r);
+                for (auto& v : B.data) v = n(r);
+                out.push_back(std::move(A)); out.push_back(std::move(B));
+            }
+            if (as.type.rfind("dora-rows", 0) == 0) {
+                // magnitude near the base row norm, as the trainer inits it, but perturbed so a
+                // magnitude == norm coincidence cannot mask a bug.
+                TensorSpec mg{ t.stem + ".magnitude", t.out, 1, {} };
+                mg.data.resize((size_t)t.out);
+                const std::vector<float>& w = base_specs[&t - &kTargets[0]].data;
+                for (int64_t o = 0; o < t.out; o++) {
+                    double s = 0;
+                    for (int64_t i = 0; i < t.in; i++) { const float v = w[(size_t)o*t.in + i]; s += (double)v*v; }
+                    mg.data[(size_t)o] = (float)std::sqrt(s) * 1.15f + 0.05f;
+                }
+                out.push_back(std::move(mg));
+            }
+        }
+        return out;
+    };
+
+    // Run one chain: merge reference vs composed functional, over every target.
+    auto run_case = [&](const std::string& label, const std::vector<AdapterSpec>& specs) {
+        std::vector<std::vector<TensorSpec>> ad_specs;
+        for (size_t i = 0; i < specs.size(); i++)
+            ad_specs.push_back(make_adapter_specs(specs[i], 7000u + (uint32_t)i * 31u));
+
+        auto load_adapters = [&]() {
+            std::vector<sa3::LoraAdapter> v(specs.size());
+            for (size_t i = 0; i < specs.size(); i++) {
+                build_model(v[i].gguf, ad_specs[i]);
+                v[i].type     = specs[i].type;
+                v[i].rank     = specs[i].rank;
+                v[i].alpha    = specs[i].alpha;
+                v[i].strength = specs[i].strength;
+            }
+            return v;
+        };
+
+        // reference: sequential in-place merge, the shipped f16/f32 path
+        sa3::GgufModel merged;  build_model(merged, base_specs);
+        std::vector<sa3::LoraAdapter> ad_ref = load_adapters();
+        sa3::apply_loras(merged, ad_ref);
+
+        // under test: composed functional adapters over a pristine base
+        sa3::GgufModel func;    build_model(func, base_specs);
+        std::vector<sa3::LoraAdapter> ad_fun = load_adapters();
+        sa3::FunctionalLora fl = sa3::build_functional_lora(func, ad_fun, "");
+        expect(fl.active, label + ": functional path engaged");
+        if (!fl.active) return;
+
+        ggml_init_params ip = { 32u << 20, nullptr, false };
+        ggml_context* c = ggml_init(ip);
+        ggml_cgraph* g = ggml_new_graph_custom(c, 4096, false);
+        std::vector<ggml_tensor*> refs, funs;
+        for (size_t ti = 0; ti < kTargets.size(); ti++) {
+            const Target& t = kTargets[ti];
+            const std::string wname = t.stem + ".weight";
+            ggml_tensor* x = ggml_new_tensor_2d(c, GGML_TYPE_F32, t.in, SEQ);
+            std::memcpy(x->data, xs[ti].data(), xs[ti].size() * sizeof(float));
+            ggml_tensor* rw = ggml_new_tensor_2d(c, GGML_TYPE_F32, t.in, t.out);
+            ggml_backend_tensor_get(merged.tensors[wname], rw->data,
+                                    0, (size_t)t.in * t.out * sizeof(float));
+            refs.push_back(ggml_mul_mat(c, rw, x));
+            funs.push_back(sa3::dit_lin(c, func, wname, x, nullptr, &fl.map));
+            ggml_build_forward_expand(g, refs.back());
+            ggml_build_forward_expand(g, funs.back());
+        }
+        sa3_test_compute(g);
+
+        for (size_t ti = 0; ti < kTargets.size(); ti++) {
+            const Target& t = kTargets[ti];
+            // Scale the error by the RMS of the reference output, not by each element. The two
+            // paths sum in different orders -- the reference forms W+delta and contracts once over
+            // `in`, the functional path adds a separately accumulated residual -- so wherever the
+            // base and the residual nearly cancel, a per-element relative error explodes on a
+            // near-zero output while the absolute error stays at f32 epsilon.
+            double sumsq = 0.0, maxabs = 0.0, worst_r = 0.0;
+            for (int64_t k = 0; k < t.out * SEQ; k++) {
+                const double r = ((float*)refs[ti]->data)[k], f = ((float*)funs[ti]->data)[k];
+                sumsq += r * r;
+                if (std::fabs(r - f) > maxabs) { maxabs = std::fabs(r - f); worst_r = r; }
+            }
+            const double rms = std::sqrt(sumsq / (double)(t.out * SEQ));
+            const double err = maxabs / rms;
+            if (getenv("VERBOSE"))
+                std::printf("  %-34s %-16s err=%.3e  (maxabs=%.2e at |ref|=%.2e, rms=%.2e)\n",
+                            label.c_str(), t.stem.c_str(), err, maxabs, std::fabs(worst_r), rms);
+            expect(err < 1e-5, label + " @ " + t.stem + " (err " + std::to_string(err) + ")");
+        }
+        ggml_free(c);
+        fl.free();
+    };
+
+    const AdapterSpec dora   { "dora-rows", 2, 4.0f, 1.0f, false };
+    const AdapterSpec dora2  { "dora-rows", 4, 8.0f, 1.0f, false };
+    const AdapterSpec plain  { "lora",      2, 4.0f, 1.0f, false };
+    const AdapterSpec doraS  { "dora-rows", 2, 4.0f, 0.6f, false };   // non-unit strength
+    const AdapterSpec plainS { "lora",      3, 6.0f, 1.7f, false };
+    const AdapterSpec doraSolo{ "dora-rows", 2, 4.0f, 1.0f, true };   // skips one target
+    const AdapterSpec doraXs { "dora-rows-xs", 2, 4.0f, 1.0f, false };
+    const AdapterSpec loraXs { "lora-xs",      2, 4.0f, 1.0f, false };
+
+    // single adapter: the already-validated path must not regress
+    run_case("1x dora-rows",           { dora });
+    run_case("1x lora",                { plain });
+    // composition
+    run_case("2x dora-rows",           { dora, dora2 });
+    run_case("3x dora-rows",           { dora, dora2, doraS });
+    run_case("2x lora",                { plain, plainS });
+    run_case("lora then dora-rows",    { plain, dora });
+    run_case("dora-rows then lora",    { dora, plain });
+    run_case("dora, lora, dora",       { dora, plainS, dora2 });
+    run_case("2x dora, strengths",     { doraS, dora2 });
+    // partial overlap: the chain is per target, not global
+    run_case("dora + dora(skips one)", { dora, doraSolo });
+    run_case("dora(skips one) + dora", { doraSolo, dora });
+    // -xs families: delta = U @ M_xs @ Vᵗ regrouped into the same term structure
+    run_case("1x dora-rows-xs",        { doraXs });
+    run_case("1x lora-xs",             { loraXs });
+    run_case("dora-rows-xs + lora",    { doraXs, plain });
+    run_case("lora-xs + dora-rows",    { loraXs, dora });
+    run_case("dora-rows + dora-rows-xs", { dora, doraXs });
+
+    // The chain must not commute: swapping two dora adapters has to change the output. Both
+    // orders match their own merge reference above, so this only has to prove they differ.
+    {
+        auto composed_out = [&](const std::vector<AdapterSpec>& specs) {
+            std::vector<std::vector<TensorSpec>> ad_specs;
+            for (size_t i = 0; i < specs.size(); i++)
+                ad_specs.push_back(make_adapter_specs(specs[i], 4242u + (uint32_t)i * 17u));
+            sa3::GgufModel base; build_model(base, base_specs);
+            std::vector<sa3::LoraAdapter> ads(specs.size());
+            for (size_t i = 0; i < specs.size(); i++) {
+                build_model(ads[i].gguf, ad_specs[i]);
+                ads[i].type = specs[i].type; ads[i].rank = specs[i].rank;
+                ads[i].alpha = specs[i].alpha; ads[i].strength = specs[i].strength;
+            }
+            sa3::FunctionalLora fl = sa3::build_functional_lora(base, ads, "");
+            ggml_init_params ip = { 32u << 20, nullptr, false };
+            ggml_context* c = ggml_init(ip);
+            ggml_cgraph* g = ggml_new_graph_custom(c, 2048, false);
+            const Target& t = kTargets[0];
+            ggml_tensor* x = ggml_new_tensor_2d(c, GGML_TYPE_F32, t.in, SEQ);
+            std::memcpy(x->data, xs[0].data(), xs[0].size() * sizeof(float));
+            ggml_tensor* y = sa3::dit_lin(c, base, t.stem + ".weight", x, nullptr, &fl.map);
+            ggml_build_forward_expand(g, y);
+            sa3_test_compute(g);
+            std::vector<float> out((float*)y->data, (float*)y->data + t.out * SEQ);
+            ggml_free(c); fl.free();
+            return out;
+        };
+        // two dora adapters that differ (different rank/alpha), so order genuinely matters
+        std::vector<float> ab = composed_out({ dora, dora2 });
+        std::vector<float> ba = composed_out({ dora2, dora });
+        double maxrel = 0.0;
+        for (size_t k = 0; k < ab.size(); k++)
+            maxrel = std::max(maxrel, (double)std::fabs(ab[k] - ba[k]) / (std::fabs(ab[k]) + 1e-4));
+        expect(maxrel > 1e-3, "dora chain does not commute (order is respected)");
+    }
+
+    // dora-cols / bora stay on the merge path: their scale factors onto the input, which needs a
+    // chain-dependent column norm of the base and a Wᵗ-side contraction (see lora.h).
+    {
+        std::vector<sa3::LoraAdapter> v(1);
+        v[0].type = "bora";
+        expect(!sa3::functional_lora_ok(v), "bora is rejected by the functional path");
+        v[0].type = "dora-cols";
+        expect(!sa3::functional_lora_ok(v), "dora-cols is rejected by the functional path");
+        v[0].type = "dora-rows";
+        expect(sa3::functional_lora_ok(v), "dora-rows is accepted");
+        std::vector<sa3::LoraAdapter> two(2);
+        two[0].type = "dora-rows"; two[1].type = "lora-xs";
+        expect(sa3::functional_lora_ok(two), "a mixed row-family chain is accepted");
+        two[1].type = "dora-cols";
+        expect(!sa3::functional_lora_ok(two), "one column-family member rejects the whole chain");
+    }
+
+    if (fails) return 1;
+    std::printf("lora_compose_test: ok\n");
+    return 0;
+}

--- a/tests/model_artifacts_test.py
+++ b/tests/model_artifacts_test.py
@@ -8,7 +8,9 @@ import sys
 import unittest
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(REPO_ROOT / "tools"))
 
 from model_artifacts import build_download_plan, dit_filename, dit_identity
 from stage_training_base_repos import notice_text
@@ -55,7 +57,7 @@ class ModelArtifactsTest(unittest.TestCase):
     def assert_downloader_plan(self, command):
         result = subprocess.run(
             command,
-            cwd=Path(__file__).resolve().parents[1],
+            cwd=REPO_ROOT,
             check=True,
             text=True,
             capture_output=True,
@@ -69,6 +71,9 @@ class ModelArtifactsTest(unittest.TestCase):
         )
         self.assertIn("t5gemma-b-b-ul2-v1.0-vocab.gguf", output)
 
+    # models.sh stays a RELATIVE path: shutil.which("bash") may resolve to the WSL shim in
+    # WindowsApps, whose filesystem namespace has no C:\ — an absolute Windows path fails there
+    # with exit 127, while a relative one resolves against the cwd WSL translates for us.
     def test_shell_downloader_training_base_plan(self):
         bash = shutil.which("bash")
         if not bash:
@@ -78,10 +83,16 @@ class ModelArtifactsTest(unittest.TestCase):
             "--training-base", "--dry-run", "--out", "test-models",
         ])
 
+    # models.cmd, by contrast, is named ABSOLUTELY: `cmd.exe /c models.cmd` resolves the script
+    # through the executable search, and a process environment carrying
+    # NoDefaultCurrentDirectoryInExePath=1 drops the current directory from that search (agent and
+    # tool shells set it; ordinary shells and CI do not). The test would then fail with
+    # "'models.cmd' is not recognized" despite cwd being correct — a false alarm about the
+    # downloader, so pin the path rather than depend on the lookup.
     @unittest.skipUnless(os.name == "nt", "Windows command script")
     def test_cmd_downloader_training_base_plan(self):
         self.assert_downloader_plan([
-            "cmd.exe", "/d", "/c", "models.cmd", "--variant", "small-sfx",
+            "cmd.exe", "/d", "/c", str(REPO_ROOT / "models.cmd"), "--variant", "small-sfx",
             "--encoding", "f32", "--training-base", "--dry-run", "--out", "test-models",
         ])
 

--- a/tools/sa3-quantize.cpp
+++ b/tools/sa3-quantize.cpp
@@ -48,6 +48,12 @@ static const QuantMix MIXES[] = {
     // unreachable, leaving the backends' q5_K get_rows kernels untested by this tool.
     { "q5_k",   GGML_TYPE_Q5_K, GGML_TYPE_Q5_K },
     { "q8_0",   GGML_TYPE_Q8_0, GGML_TYPE_Q8_0 },
+    // Re-encode targets rather than quantization. --mix f16 on an already-quantized gguf
+    // dequantizes it back to F16, keeping the quantization error: an F16-sized model that is
+    // numerically the quantized one. Lets code paths that cannot read quantized tensors
+    // (LoRA weight-space merging) be measured against quantized weights.
+    { "f16",    GGML_TYPE_F16,  GGML_TYPE_F16  },
+    { "f32",    GGML_TYPE_F32,  GGML_TYPE_F32  },
 };
 
 // Compact spellings accepted for convenience; they resolve to the canonical mix above.
@@ -125,11 +131,13 @@ int main(int argc, char ** argv) {
 
     if (!in_path || !out_path || !mixp) {
         if (in_path && out_path && !mixp) fprintf(stderr, "error: unknown --mix '%s'\n", mix_name);
-        fprintf(stderr, "Usage: sa3-quantize --in <input.gguf> --out <output.gguf> [--mix q4_k_m|q5_k_m|q5_k|q8_0]\n");
+        fprintf(stderr, "Usage: sa3-quantize --in <input.gguf> --out <output.gguf> [--mix q4_k_m|q5_k_m|q5_k|q8_0|f16|f32]\n");
         fprintf(stderr, "  q4_k_m  V/down/embed -> Q6_K, rest -> Q4_K   (default)\n");
         fprintf(stderr, "  q5_k_m  V/down/embed -> Q6_K, rest -> Q5_K\n");
         fprintf(stderr, "  q5_k    everything   -> Q5_K   (no Q6_K promotion; exercises q5_K get_rows)\n");
         fprintf(stderr, "  q8_0    everything   -> Q8_0\n");
+        fprintf(stderr, "  f16     everything   -> F16   (re-encode; dequantizes a quantized input)\n");
+        fprintf(stderr, "  f32     everything   -> F32   (re-encode)\n");
         fprintf(stderr, "Skips sa3-conditioner/sa3-tokenizer (must stay F32).\n");
         return 1;
     }
@@ -185,8 +193,8 @@ int main(int argc, char ** argv) {
     fclose(f);
 
     // Pre-init quantization tables
-    ggml_quantize_init(mix.body);
-    if (mix.critical != mix.body) ggml_quantize_init(mix.critical);
+    if (ggml_is_quantized(mix.body)) ggml_quantize_init(mix.body);
+    if (ggml_is_quantized(mix.critical) && mix.critical != mix.body) ggml_quantize_init(mix.critical);
 
     // ── Build output context (metadata only, no data yet) ────
     struct gguf_context * out_ctx = gguf_init_empty();
@@ -273,13 +281,32 @@ int main(int argc, char ** argv) {
             for (int64_t j = 0; j < n_elems; j++) {
                 f32_buf[j] = ggml_fp16_to_fp32(f16[j]);
             }
+        } else if (ggml_is_quantized(stype)) {
+            // Quantized input: dequantize row by row via the type's own reference
+            // unpacker, so re-encoding an already-quantized gguf works (--mix f16
+            // round-trips a k-quant model back to F16 with its quantization error baked in).
+            const ggml_type_traits * tr = ggml_get_type_traits(stype);
+            if (!tr || !tr->to_float) {
+                fprintf(stderr, "ERROR: no dequantizer for %s\n", ggml_type_name(stype));
+                return 1;
+            }
+            const size_t row_bytes = ggml_row_size(stype, ne0);
+            for (int64_t r = 0; r < ne1; r++) {
+                tr->to_float(src_ptr + (size_t)r * row_bytes, f32_buf.data() + r * ne0, ne0);
+            }
         } else {
             fprintf(stderr, "ERROR: unsupported type %s\n", ggml_type_name(stype));
             return 1;
         }
 
         char * dst = data_buf.data() + out_off;
-        ggml_quantize_chunk(dtype, f32_buf.data(), dst, 0, ne1, ne0, nullptr);
+        if (dtype == GGML_TYPE_F32) {
+            memcpy(dst, f32_buf.data(), (size_t)n_elems * sizeof(float));
+        } else if (dtype == GGML_TYPE_F16) {
+            ggml_fp32_to_fp16_row(f32_buf.data(), (ggml_fp16_t *)dst, n_elems);
+        } else {
+            ggml_quantize_chunk(dtype, f32_buf.data(), dst, 0, ne1, ne0, nullptr);
+        }
 
         fprintf(stderr, "%s  [%lld x %lld]\n",
                 ggml_type_name(dtype), (long long)ne0, (long long)ne1);


### PR DESCRIPTION
Ready to merge. Every item on the original checklist is closed: Metal measured, multi-adapter
composition implemented and tested, the `-xs` families added, and the branch rebased onto
`15dd87a`. Final validation was re-run on the PC (CUDA, RTX 5070) after the rebase.

## What this does

A LoRA could not be applied to a quantized base at all. `apply_loras` rewrites `W` in place,
which means reading `W` out and writing `W_eff` back, and neither direction has a route for
k-quant types — the graph path aborts in `ggml_cast` (`unsupported type combination
(q6_K to f32)`) and the host path cannot re-pack an f32 result into Q4_K storage. So
`--lora X --encoding q4_k_m` was a hard abort.

This hands the adapter tensors to `dit_lin` instead, which folds them into the graph as
`y = W@x + s·B@(A@x)` plus the dora row scale. `W` is then only ever an argument to `mul_mat`,
and quantized `mul_mat` works on every backend, so the base is never dequantized or rewritten.
`dit_lin` already did exactly this for the training graph; inference just passed `dl = nullptr`.

## Multiple adapters compose exactly

Blending several adapters is central to how these models actually get used, so the functional
path composes a whole chain rather than handling one adapter. Merging sequentially — each
adapter reading the previous one's `W_eff`, which is what `apply_loras` does — expands with **no
approximation** into

```
y = c_0 ⊙ (W@x) + Σ_k s_k · c_k ⊙ (B_k @ (A_k @ x))
c_0 = Π_{dora j} d_j        c_k = Π_{dora j, j >= k} d_j
```

with `d_j` the dora row scale of adapter `j`. Every `c` is constant at inference, so they are
precomputed once and folded into the term tensors: the per-step graph costs one broadcast
multiply plus the residuals, regardless of how many adapters stack. A later dora rescaling
earlier residuals is exactly why the chain does not commute, and the suffix scan preserves that.

"dora does not commute" was the original reason for the one-adapter limit. That was true but it
never implied an approximation was needed — non-commuting only means order matters, and the
recursion keeps the order.

`tests/lora_compose_test.cpp` pins the composed form against the **real merge path** over 16
chains, so the test references `apply_loras` rather than my own algebra.

The precompute reuses what one adapter already needed: `base_norm_sq` (unchanged, still
adapter-independent, so the sidecar stays valid), one `mul_mat(W, A_k)` per adapter, and one
rank×rank gram per adapter *pair*. A purely additive chain needs no norms at all and skips the
host read entirely.

This also covers the `-xs` families, since `U @ M_xs @ Vᵗ` is still rank-r and regroups into the
same terms.

## Results

medium, 20 s output, 8 steps, kev (dora-rows, rank 16), warm, base-norm cache primed:

| backend | path | dit_compute | total | peak VRAM |
| --- | --- | --- | --- | --- |
| CUDA | f16 + merged | 699 ms | 5653 ms | 2994 MiB |
| CUDA | q4_k_m + functional | 728 ms | **3545 ms** | **1278 MiB** |
| Vulkan | f16 + merged | 523 ms | 6674 ms | 3049 MiB |
| Vulkan | q4_k_m + functional | 712 ms | **4310 ms** | **1248 MiB** |
| Metal M4 | f16 + merged | 4925 ms | 13520 ms | 3071 MiB |
| Metal M4 | q4_k_m + functional | 6340 ms | **11720 ms** | **1973 MiB** |

37% faster end to end on CUDA, 35% on Vulkan, 13% on Metal, and ~58%/~59%/36% less memory.

**The win is not per-step.** `dit_compute` is *worse* functionally — +4% CUDA, +36% Vulkan,
+22% Metal — because the residual matmuls are real per-step work the merged path does once up
front. The end-to-end gain comes entirely from loading a 1532 MiB model instead of a 4399 MiB
one.

Two composed adapters (kev + keygen, both dora-rows rank 16, 228 targets, CUDA, 20 s / 8 steps):

| path | dit_compute | total | peak VRAM |
| --- | --- | --- | --- |
| f16 + merged | 816 ms | 6724 ms | 3213 MiB |
| q4_k_m + functional | 1033 ms | **4230 ms** | **1423 MiB** |

37% faster end to end and 56% less VRAM, with a bigger per-step cost (+27%) than one adapter
because there are now two residuals per target.

**On Metal at 8 steps it already inverts, even on f16**: merging costs ~2.4 s up front there,
and at 8 steps that outweighs the accumulated residual cost.

| steps (Metal M4, f16) | merged | functional |
|---:|---:|---:|
| 8 | 13.52 s | **12.18 s** |
| 32 | 29.30 s | 29.97 s |

Crossover is ~20–25 steps and 8 is the common case, but the default is deliberately left alone:
one machine and one adapter type is not enough to move it, and `dora-rows` merging also pays for
dora row work a plain `lora` merge would not. If the crossover holds on CUDA/Vulkan too, the
heuristic wants to be step-count aware rather than dtype-aware, which is its own change.

## Accuracy

Judge this **per forward pass, not per generation**. At one diffusion step, functional vs merged
on the same f16 base is **0.999878 (one adapter) and 0.999876 (two adapters)** — composition adds
no error.

Over 8 steps the same comparison lands anywhere from 0.977 to 0.9995, because a ~1e-4 per-pass
difference compounds into a different-but-valid trajectory. Those numbers move with prompt and
seed and should not be read as a quality ordering: Metal measured 0.999711, CUDA 0.991400,
Vulkan 0.950966, against 0.9968 for identical weights across CUDA/CPU and 0.9714 for medium f16
across CUDA/Vulkan. Vulkan is simply looser between any two paths.

## Two things that made it viable

- **Precomputed row scale** (`d1e2a69`). `dit_lin` recomputed the dora-rows norms every step via
  `mul_mat(W, A)` over the full base weight — necessary while training, where A and B move, but
  at inference `W`, `A` and `B` are all frozen, so the row scale is a constant. Computing it once
  dropped `dit_compute` from 885 ms to 722 ms (+47% → +20%). The one-shot graph reuses
  `dit_lin`'s exact op sequence so the shortcut cannot drift from the reference. Training leaves
  it null and is untouched.
- **Cached base norms** (`e2bec09`). `base_norm_sq` needs every targeted weight pulled to the
  host and squared, ~1.5B elements for the medium DiT: +3.4 s on q4_k_m, +4.6 s on f16 (worse
  there — larger weights to transfer, so not a quantization problem). It depends only on the base
  weights, never the adapter, so it is cached in `<model>.gguf.norms` keyed on the model's byte
  size. First run 6647 ms, every run after 3512 ms. 3.3 MB sidecar for 228 tensors, and
  backend-independent — a cache written by CUDA is reused by Vulkan. Written temp-then-rename so
  an interrupted run cannot leave a half-written cache that later reads as valid.

## No behaviour change to existing paths

- f16/f32 bases still **merge by default**; the merge costs nothing per step. The functional path
  engages only when the base is quantized, or when `SA3_FUNCTIONAL_LORA` is set, to A/B the two
  on f16.
- Supported functionally: the row-normalizing families — `lora`, `dora-rows` and their `-xs`
  variants — in any number and any mix. `dora-cols` and `bora` still merge, so they need f16/f32.
  They normalize over `in`, so their scale lands on the *input*, needing a column norm of the base
  weighted by the row scales accumulated so far — chain-dependent, so unlike `base_norm_sq` it
  cannot be cached per base — plus cross terms contracting against `Wᵗ`, which quantized `mul_mat`
  does not support.
- Training is untouched.
- What was a raw ggml abort on `--lora` + quantized is now either a working generation or a clear
  error naming the constraint.

`--mix f16/f32` on `sa3-quantize` came along for the ride: it re-encodes an already-quantized
gguf, so dequantizing Q4_K_M back to F16 yields a model that is numerically the quantized one but
readable by code that cannot handle quantized tensors. That is how the quality question was
answered before this path existed, and it is what proved the round-trip is a faithful proxy
(0.995400 vs 0.995778 against true F16 on a single forward pass).

## Fixes folded in

- `SA3_FUNCTIONAL_LORA` was a bare `getenv` presence test, so `=0` *enabled* it. Now compares
  against `"0"`.
- `lora.h` referenced `DitLora`/`DitLoraParam` without including `dit.h`, compiling only where an
  earlier include happened to pull it in first. #27 changed that ordering and broke
  `sa3-train-checkpoint-test` with `unknown type name 'DitLora'` on rebase. Fixed in `9bc9533`.

## Validation

Re-run on the PC after the rebase, CUDA / RTX 5070:

- 17/17 ctest pass, including the new `sa3-lora-compose-test` and `sa3-train-checkpoint-test`.
- `--encoding q4_k_m --lora kev` → `lora: applied 1 adapter(s) [functional]`, real audio out.
- `--encoding q4_k_m --lora kev --lora keygen` → `lora: applied 2 adapter(s) [functional]`.
- `--encoding q4_k_m --lora <bora>` → rejected with the constraint message, as intended.
