### PR TITLE
server: serve a front-end directory with --web-dir

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -16,6 +16,7 @@ for progress and, on completion, the base64 audio. That makes it a drop-in for a
 #       --threads N (or SA3_THREADS, CPU backend only)
 #       --prompts-dir DIR (or SA3_PROMPTS_DIR)
 #       --source-loras-dir DIR (or SA3_SOURCE_LORAS_DIR)
+#       --web-dir DIR (or SA3_WEB_DIR) — serve a front-end at / ; omit for API only
 ```
 
 on Windows, after `.\build.cmd cuda`, `server.cmd` picks the built backend and keeps the server in the terminal (close it or Ctrl+C to stop). extra args pass through:
@@ -213,6 +214,37 @@ next request — keeps host-process memory low (good for an embedded/VST context
 strength correct for free. for a long-running service that wants lowest latency, send `keep_models:true`
 and call `POST /unload` from your orchestrator when you need the VRAM back (model-switch, idle, pressure) —
 the same pattern as the pytorch sa3 service.
+
+## serving a front-end (`--web-dir`)
+
+off by default. without it the server is API only and `GET /` is a 404, unchanged from before
+this existed.
+
+```sh
+sa3-server --web-dir ./web          # or SA3_WEB_DIR=./web
+```
+
+everything under that directory is served at `/`: `GET /` resolves to `index.html`, `GET /app.js`
+to `web/app.js`, and so on. the point is that a front-end can live as plain files next to the
+server, kept and versioned wherever its author wants, without being compiled into the binary and
+without patching `sa3-server.cpp` to add a route per asset.
+
+the serving is httplib's own file handler, not hand-rolled. it rejects `..`, backslashes and nulls
+in the request path, then canonicalizes the result and re-checks it against the base directory so a
+symlink or junction cannot escape either. it also sets `ETag` and `Last-Modified`, and redirects a
+directory to its trailing-slash form.
+
+two behaviours worth knowing:
+
+- **static files are matched before route handlers, and only for GET/HEAD.** so a file named
+  `health`, `loras` or `prompts` in the web dir would shadow that GET endpoint. the server warns
+  at startup if it finds one. `POST` routes (`/generate`, `/generate/loop`, `/unload`) can never be
+  shadowed.
+- **a bad `--web-dir` is fatal.** pointing it at something that is not a directory exits non-zero
+  rather than starting up and quietly serving nothing.
+
+if the directory has no `index.html` the server still starts, notes it, and `/` will 404 until one
+exists — useful when the assets are built into place after launch.
 
 ## notes
 

--- a/tools/sa3-server.cpp
+++ b/tools/sa3-server.cpp
@@ -53,6 +53,7 @@ std::string g_models_dir;
 std::string g_adapters_dir;
 std::string g_prompts_dir;
 std::string g_source_loras_dir;
+std::string g_web_dir;                    // --web-dir: serve this directory at /; empty = API only
 int g_cpu_threads = 0;
 
 // --- async job registry (mirrors gary4local /poll_status) ---
@@ -757,6 +758,7 @@ int main(int argc, char** argv) {
     if (const char* e = getenv("SA3_ADAPTERS_DIR")) g_adapters_dir = e;
     if (const char* e = getenv("SA3_PROMPTS_DIR"))  g_prompts_dir  = e;
     if (const char* e = getenv("SA3_SOURCE_LORAS_DIR")) g_source_loras_dir = e;
+    if (const char* e = getenv("SA3_WEB_DIR"))      g_web_dir      = e;
     if (g_models_dir.empty()) g_models_dir = "models";
     if (g_prompts_dir.empty()) g_prompts_dir = "prompts";
     if (g_source_loras_dir.empty()) g_source_loras_dir = "loras";
@@ -772,6 +774,7 @@ int main(int argc, char** argv) {
         else if (a == "--adapters-dir") g_adapters_dir = next("");
         else if (a == "--prompts-dir")  g_prompts_dir = next("prompts");
         else if (a == "--source-loras-dir") g_source_loras_dir = next("loras");
+        else if (a == "--web-dir")      g_web_dir = next("");
         else if (a == "--threads")      { g_cpu_threads = atoi(next("0")); threads_set = true; }
     }
     if (threads_set && g_cpu_threads <= 0) {
@@ -783,6 +786,38 @@ int main(int argc, char** argv) {
     const std::string sldir = g_source_loras_dir;
 
     httplib::Server svr;
+
+    // --web-dir: serve a directory of static files at /, so a front-end lives beside the server
+    // as plain files instead of being compiled in. Off by default; without it this is API-only
+    // and behaves exactly as before.
+    //
+    // httplib's own file handler does the serving: it rejects ".." and backslashes in the URL,
+    // then canonicalizes and re-checks the result against the base directory so a symlink cannot
+    // escape either. It also resolves a trailing "/" to index.html and sets ETag/Last-Modified.
+    if (!g_web_dir.empty()) {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+        if (!fs::is_directory(g_web_dir, ec)) {
+            fprintf(stderr, "[sa3-server] --web-dir '%s' is not a directory\n", g_web_dir.c_str());
+            return 1;   // fail loudly: silently serving nothing is worse than not starting
+        }
+        // httplib checks static files BEFORE route handlers, and only for GET/HEAD. So a file
+        // whose name collides with a GET endpoint would shadow the API. POST routes (/generate,
+        // /generate/loop, /unload) cannot be shadowed. Warn rather than refuse: it is the
+        // caller's directory, and a collision is legal, just almost certainly a mistake.
+        for (const char* reserved : {"health", "loras", "prompts"}) {
+            if (fs::exists(fs::path(g_web_dir) / reserved, ec))
+                fprintf(stderr, "[sa3-server] warning: %s/%s shadows the GET /%s endpoint\n",
+                        g_web_dir.c_str(), reserved, reserved);
+        }
+        if (!svr.set_mount_point("/", g_web_dir)) {
+            fprintf(stderr, "[sa3-server] failed to mount --web-dir '%s'\n", g_web_dir.c_str());
+            return 1;
+        }
+        if (!fs::exists(fs::path(g_web_dir) / "index.html", ec))
+            fprintf(stderr, "[sa3-server] note: no index.html in %s; / will 404 until one exists\n",
+                    g_web_dir.c_str());
+    }
 
     svr.Get("/health", [](const httplib::Request&, httplib::Response& res) {
         const bool loaded = g_loaded.load();   // atomic: never blocks behind an in-flight generation
@@ -1008,8 +1043,9 @@ int main(int argc, char** argv) {
         res.set_content(body, "application/json");
     });
 
-    fprintf(stderr, "[sa3-server] http://%s:%d  model=%s/%s  models=%s  adapters=%s  source_loras=%s  prompts=%s  (async /poll_status; frugal default)\n",
-            host.c_str(), port, g_variant.c_str(), g_encoding.c_str(), g_models_dir.c_str(), adir.c_str(), sldir.c_str(), pdir.c_str());
+    fprintf(stderr, "[sa3-server] http://%s:%d  model=%s/%s  models=%s  adapters=%s  source_loras=%s  prompts=%s  web=%s  (async /poll_status; frugal default)\n",
+            host.c_str(), port, g_variant.c_str(), g_encoding.c_str(), g_models_dir.c_str(), adir.c_str(), sldir.c_str(), pdir.c_str(),
+            g_web_dir.empty() ? "(none)" : g_web_dir.c_str());
     if (!svr.listen(host.c_str(), port)) {
         fprintf(stderr, "[sa3-server] failed to bind %s:%d\n", host.c_str(), port);
         return 1;


### PR DESCRIPTION
First of the two changes from #22 aimed at getting @pillopaus-project's web interface to
zero changes in our C++. Deliberately small and standalone so it can be argued with before
it lands.

## The problem

Today a front-end has to be compiled into the binary (`embedded_web.h`, regenerated by a
script) and reach the network by patching `sa3-server.cpp` to add a route per asset. That
means every UI edit regenerates a header, and every one of our changes to that file is a
rebase for whoever maintains the UI.

## What this does

```sh
sa3-server --web-dir ./web          # or SA3_WEB_DIR=./web
```

Serves that directory at `/`. `GET /` resolves to `index.html`, `GET /app.js` to
`web/app.js`, and so on. Off by default — without the flag the server is API only and
`GET /` is a 404, exactly as before.

The serving is httplib's own file handler, not hand-rolled: it rejects `..`, backslashes
and nulls in the path, then canonicalizes the result and re-checks it against the base
directory so a symlink or junction cannot escape either. It also supplies `ETag` /
`Last-Modified` and directory redirects.

## Two rough edges, surfaced rather than hidden

- **httplib matches static files before route handlers, and only for GET/HEAD.** A file
  named `health`, `loras` or `prompts` in the web dir would shadow that GET endpoint. The
  server warns at startup if it finds one. POST routes (`/generate`, `/generate/loop`,
  `/unload`) can never be shadowed. I chose warn-not-refuse because it is the caller's
  directory and the collision is legal, just almost certainly a mistake — happy to make it
  fatal if that reads better.
- **A `--web-dir` that is not a directory exits non-zero** rather than starting up and
  quietly serving nothing. A missing `index.html` is only a note, so assets can be built
  into place after launch.

## Verified

| case | result |
| --- | --- |
| `GET /`, `/app.js`, `/sub/style.css` | 200, correct bodies |
| `GET /health` with web dir mounted | 200, still the API |
| `GET /nope.js` | 404 |
| `/../secret`, `/../../secret`, `/sub/../../secret` | 404, nothing leaked |
| `/%2e%2e/secret`, `/..%2fsecret`, `/....//secret` | 404, nothing leaked |
| `/..\secret`, `/sub\..\..\secret` | 404, nothing leaked |
| file named `health` in web dir | warned at startup, and does shadow |
| `--web-dir` at a non-directory | exits 1 with a clear message |
| no `--web-dir` | `web=(none)`, `GET /` 404, `GET /health` 200 |

## What this does not cover

@pillopaus-project — this replaces the `/` and `/app.js` routes in your `web-app` branch and
retires `embedded_web.h` plus `gen_embedded_web.py`, but it does **not** cover `/init-audio`
and `/init-audio/upload`. Those are a real API feature, not static files, so static serving
cannot absorb them; upstreaming them is a separate piece and I would rather take your version
than reinvent it.

Also worth flagging: your `web-app` branch rebases onto current `main` completely clean — I
trial-merged it, zero conflicts — so nothing here blocks you in the meantime.

`SA3_WEB_DIR` follows the existing env+flag convention the other directories use. The server
config work is the other half of #22 and will fold all of them into one place; this keeps the
surface consistent until then rather than inventing a second pattern.
