### PR TITLE
server: init-audio pool for browser clients

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -17,6 +17,7 @@ for progress and, on completion, the base64 audio. That makes it a drop-in for a
 #       --prompts-dir DIR (or SA3_PROMPTS_DIR)
 #       --source-loras-dir DIR (or SA3_SOURCE_LORAS_DIR)
 #       --web-dir DIR (or SA3_WEB_DIR) — serve a front-end at / ; omit for API only
+#       --audio-in-dir DIR (or SA3_AUDIO_IN_DIR) — init-audio pool for browser clients
 ```
 
 on Windows, after `.\build.cmd cuda`, `server.cmd` picks the built backend and keeps the server in the terminal (close it or Ctrl+C to stop). extra args pass through:
@@ -38,6 +39,8 @@ it binds to `127.0.0.1` by default (local only). The model loads lazily on the f
 | `POST` | `/generate/loop` | same request plus `bpm`/prompt BPM and `bars` for exact-length loop generation |
 | `GET`  | `/poll_status/<session_id>` | `{success, generation_in_progress, progress, step, total_steps, status, queue_status, ...}`; on `status:"completed"` also `audio_data` (base64 wav) + `meta:{seed}` |
 | `POST` | `/unload`   | frees the model (full VRAM release) → `{status:"unloaded"}` |
+| `GET`  | `/init-audio` | `{success, files:[{name,path,bytes}], audio_in_dir, max_upload_bytes}` — the init-audio pool |
+| `POST` | `/init-audio/upload` | multipart `file=` → `{success, name, path, bytes}`; the returned `path` is what you pass as `init_path` |
 
 `status` runs `queued → generating → encoding → completed` (or `failed`); `progress` is `0..100`
 (sampling `0→90`, decode `→100`). poll until `status == "completed"`, then base64-decode `audio_data`.
@@ -214,6 +217,49 @@ next request — keeps host-process memory low (good for an embedded/VST context
 strength correct for free. for a long-running service that wants lowest latency, send `keep_models:true`
 and call `POST /unload` from your orchestrator when you need the VRAM back (model-switch, idle, pressure) —
 the same pattern as the pytorch sa3 service.
+
+## the init-audio pool (`--audio-in-dir`)
+
+`/generate` takes `init_path`, a path on the server's filesystem. That is the right shape for a
+DAW plug-in or a DAW extension: it can write a wav anywhere and name it. A browser cannot. It has
+no filesystem to write to and no way to learn which paths exist, so without these two endpoints a
+browser front-end can do text2music but not audio2audio, continuation or inpaint.
+
+```sh
+sa3-server --audio-in-dir ./audio-in     # or SA3_AUDIO_IN_DIR; defaults to ./audio-in
+```
+
+`GET /init-audio` lists the `.wav` files in the pool with their absolute paths. `POST
+/init-audio/upload` takes a multipart `file=` part and puts one there. The `path` it returns is
+exactly what you hand back as `init_path`, so the round trip is: upload, take the path, generate.
+
+Nothing else uses these. A client that can already write files should keep passing `init_path`
+directly and ignore them.
+
+### what the upload accepts
+
+The filename in a multipart part is attacker-controlled, so it is checked rather than cleaned:
+
+- **bare filenames only.** anything that is not already a plain name is rejected, not normalised.
+  `../../x.wav` is a `400`, not a quiet rename to `x.wav` — a client sending that is broken or
+  hostile and should hear about it. This matters more than it looks: `fs::path(dir) / name` does
+  **not** keep the result under `dir` if `name` is absolute, so `C:/Windows/Temp/x.exe` would
+  otherwise be written there verbatim.
+- **`.wav` only**, since that is what `init_path` can read.
+- **no dotfiles**, no Windows reserved device names (`con`, `nul`, `lpt1`, … — still reserved
+  with an extension), and an allowlist of characters rather than a denylist.
+- **256 MiB cap.** 300 s of stereo 44.1 kHz f32 is ~106 MiB and `SA3_MAX_DURATION` caps generation
+  at 300 s, so this is generous. An oversized body is refused with `413`, and refused *mid-stream*:
+  the upload is written straight to disk under a `.part` name and renamed on success, so it is
+  never buffered whole in memory and a client that disconnects halfway leaves nothing behind.
+- **an existing name is replaced.** re-uploading `drums.wav` overwrites it, which is what a UI
+  re-dragging the same file expects.
+
+Uploading is a write endpoint. It inherits the server's default `127.0.0.1` bind, and that is the
+only thing standing between it and the network — if you pass `--host 0.0.0.0`, anyone who can reach
+the port can put files in the pool. Note also that a localhost bind is not a trust boundary in a
+browser: any page the user has open can `POST` `multipart/form-data` cross-origin to `127.0.0.1`.
+The checks above are what keep that from being interesting.
 
 ## serving a front-end (`--web-dir`)
 

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -257,7 +257,9 @@ The filename in a multipart part is attacker-controlled, so it is checked rather
 
 Uploading is a write endpoint. It inherits the server's default `127.0.0.1` bind, and that is the
 only thing standing between it and the network — if you pass `--host 0.0.0.0`, anyone who can reach
-the port can put files in the pool. Note also that a localhost bind is not a trust boundary in a
+the port can put files in the pool. The server warns loudly at startup when it is bound to anything
+that is not loopback, rather than refusing: serving a LAN is a legitimate thing to want, it should
+just be a decision instead of a surprise. Note also that a localhost bind is not a trust boundary in a
 browser: any page the user has open can `POST` `multipart/form-data` cross-origin to `127.0.0.1`.
 The checks above are what keep that from being interesting.
 

--- a/tools/sa3-server.cpp
+++ b/tools/sa3-server.cpp
@@ -164,6 +164,18 @@ std::string lower_ascii(std::string s) {
     return s;
 }
 
+// Does this bind address reach only this machine? Anything else -- 0.0.0.0, ::, a LAN address --
+// puts the write endpoint on the network. 127.0.0.0/8 is all loopback, not just 127.0.0.1.
+bool is_loopback_host(const std::string& h) {
+    if (h == "localhost" || h == "::1" || h == "[::1]") return true;
+    if (starts_with(h, "127.")) {
+        // reject 127.foo; require the remaining octets to be numeric
+        for (char c : h.substr(4)) if (!std::isdigit((unsigned char)c) && c != '.') return false;
+        return true;
+    }
+    return false;
+}
+
 // ---- init-audio pool -------------------------------------------------------------------
 // /generate takes `init_path`, a path on the server's filesystem. That is right for a DAW
 // plug-in or an extension, which can write a wav and name it. A browser cannot: it has no
@@ -855,6 +867,16 @@ int main(int argc, char** argv) {
     if (threads_set && g_cpu_threads <= 0) {
         fprintf(stderr, "--threads must be positive\n");
         return 1;
+    }
+    // /init-audio/upload writes to disk, and the loopback default is the only thing keeping it
+    // off the network. Binding anywhere else hands that endpoint to everyone who can reach the
+    // port. Warn rather than refuse -- serving a LAN is a legitimate thing to want, but it should
+    // be a decision, not something noticed later.
+    if (!is_loopback_host(host)) {
+        fprintf(stderr, "[sa3-server] warning: bound to %s, not loopback. POST /init-audio/upload\n"
+                        "[sa3-server]          can write .wav files into %s from anywhere that can\n"
+                        "[sa3-server]          reach this port. Use --host 127.0.0.1 if that is not intended.\n",
+                host.c_str(), g_audio_in_dir.c_str());
     }
     const std::string adir = g_adapters_dir.empty() ? g_models_dir : g_adapters_dir;
     const std::string pdir = g_prompts_dir;

--- a/tools/sa3-server.cpp
+++ b/tools/sa3-server.cpp
@@ -54,6 +54,7 @@ std::string g_adapters_dir;
 std::string g_prompts_dir;
 std::string g_source_loras_dir;
 std::string g_web_dir;                    // --web-dir: serve this directory at /; empty = API only
+std::string g_audio_in_dir;               // --audio-in-dir: init-audio pool a browser can list/upload to
 int g_cpu_threads = 0;
 
 // --- async job registry (mirrors gary4local /poll_status) ---
@@ -161,6 +162,77 @@ bool ends_with(const std::string& s, const std::string& suffix) {
 std::string lower_ascii(std::string s) {
     for (char& c : s) c = (char)std::tolower((unsigned char)c);
     return s;
+}
+
+// ---- init-audio pool -------------------------------------------------------------------
+// /generate takes `init_path`, a path on the server's filesystem. That is right for a DAW
+// plug-in or an extension, which can write a wav and name it. A browser cannot: it has no
+// filesystem to write to and no way to learn what paths exist. These two endpoints are that
+// bridge and nothing more -- list the pool, and put a file in it.
+
+// Largest upload accepted. SA3_MAX_DURATION caps generation at 300 s, and 300 s of stereo
+// 44.1 kHz f32 is ~106 MiB, so this is generous for any real init audio while still bounding
+// what one request can make the server allocate on disk.
+constexpr size_t k_max_upload_bytes = 256ull * 1024 * 1024;
+
+// Reduce an upload's declared filename to something that can only ever land directly inside
+// the pool, or return "" to reject it.
+//
+// This is the part of the endpoint that has to be right. A multipart filename is attacker
+// controlled, and `fs::path(dir) / name` does NOT keep the file under `dir`: if `name` is
+// absolute, operator/ discards `dir` entirely, so "C:/Windows/Temp/x.exe" writes there. Taking
+// the basename first removes both that and any "..", after which the name is checked against
+// an allowlist rather than scrubbed, so anything surprising is refused instead of rewritten.
+std::string safe_upload_name(const std::string& raw) {
+    if (raw.empty() || raw.size() > 200) return "";
+    // Refuse, do not normalise. Taking the basename of "../../x.wav" would accept it as "x.wav"
+    // and hand back 200, hiding the fact that a client just tried to escape the pool. Anything
+    // that is not already a bare filename is a bug or an attack, and either deserves an error.
+    if (raw != std::filesystem::path(raw).filename().string()) return "";
+    if (raw == "." || raw == "..") return "";
+    if (raw.front() == '.') return "";                        // no dotfiles
+    if (!ends_with(lower_ascii(raw), ".wav")) return "";      // read_wav_planar reads wav
+    for (unsigned char c : raw) {
+        const bool ok = std::isalnum(c) || c == '.' || c == '-' || c == '_' || c == ' ' || c == '(' || c == ')';
+        if (!ok) return "";
+    }
+    // Windows reserved device names are still reserved with an extension, and opening one
+    // writes to the device rather than creating a file.
+    const std::string stem = lower_ascii(std::filesystem::path(raw).stem().string());
+    for (const char* dev : {"con","prn","aux","nul","com1","com2","com3","com4","com5","com6",
+                            "com7","com8","com9","lpt1","lpt2","lpt3","lpt4","lpt5","lpt6",
+                            "lpt7","lpt8","lpt9"}) {
+        if (stem == dev) return "";
+    }
+    return raw;
+}
+
+struct InitAudioEntry { std::string name, path; uintmax_t bytes; };
+
+std::vector<InitAudioEntry> scan_init_audio(const std::string& dir) {
+    namespace fs = std::filesystem;
+    std::vector<InitAudioEntry> out;
+    std::error_code ec;
+    if (!fs::is_directory(dir, ec)) return out;
+    for (const auto& e : fs::directory_iterator(dir, ec)) {
+        if (ec) break;
+        if (!e.is_regular_file(ec)) continue;
+        const std::string fname = e.path().filename().string();
+        if (!ends_with(lower_ascii(fname), ".wav")) continue;
+        out.push_back({fname, fs::absolute(e.path(), ec).string(), e.file_size(ec)});
+    }
+    std::sort(out.begin(), out.end(), [](const InitAudioEntry& a, const InitAudioEntry& b) { return a.name < b.name; });
+    return out;
+}
+
+std::string init_audio_json(const std::vector<InitAudioEntry>& v) {
+    std::string s = "[";
+    for (size_t i = 0; i < v.size(); i++) {
+        if (i) s += ",";
+        s += "{\"name\":\"" + json_escape(v[i].name) + "\",\"path\":\"" + json_escape(v[i].path)
+           + "\",\"bytes\":" + std::to_string((unsigned long long)v[i].bytes) + "}";
+    }
+    return s + "]";
 }
 
 std::vector<std::string> split_dash(const std::string& s) {
@@ -759,9 +831,11 @@ int main(int argc, char** argv) {
     if (const char* e = getenv("SA3_PROMPTS_DIR"))  g_prompts_dir  = e;
     if (const char* e = getenv("SA3_SOURCE_LORAS_DIR")) g_source_loras_dir = e;
     if (const char* e = getenv("SA3_WEB_DIR"))      g_web_dir      = e;
+    if (const char* e = getenv("SA3_AUDIO_IN_DIR")) g_audio_in_dir = e;
     if (g_models_dir.empty()) g_models_dir = "models";
     if (g_prompts_dir.empty()) g_prompts_dir = "prompts";
     if (g_source_loras_dir.empty()) g_source_loras_dir = "loras";
+    if (g_audio_in_dir.empty()) g_audio_in_dir = "audio-in";
     bool threads_set = false;
     for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
@@ -775,6 +849,7 @@ int main(int argc, char** argv) {
         else if (a == "--prompts-dir")  g_prompts_dir = next("prompts");
         else if (a == "--source-loras-dir") g_source_loras_dir = next("loras");
         else if (a == "--web-dir")      g_web_dir = next("");
+        else if (a == "--audio-in-dir") g_audio_in_dir = next("audio-in");
         else if (a == "--threads")      { g_cpu_threads = atoi(next("0")); threads_set = true; }
     }
     if (threads_set && g_cpu_threads <= 0) {
@@ -784,6 +859,7 @@ int main(int argc, char** argv) {
     const std::string adir = g_adapters_dir.empty() ? g_models_dir : g_adapters_dir;
     const std::string pdir = g_prompts_dir;
     const std::string sldir = g_source_loras_dir;
+    const std::string aidir = g_audio_in_dir;
 
     httplib::Server svr;
 
@@ -809,7 +885,7 @@ int main(int argc, char** argv) {
         // path prefix, so a *directory* of that name shadows it just as a file would -- and it
         // is the endpoint clients poll for generation progress, so losing it is not obvious
         // from the symptom. fs::exists covers both file and directory.
-        for (const char* reserved : {"health", "loras", "prompts", "poll_status"}) {
+        for (const char* reserved : {"health", "loras", "prompts", "poll_status", "init-audio"}) {
             if (fs::exists(fs::path(g_web_dir) / reserved, ec))
                 fprintf(stderr, "[sa3-server] warning: %s/%s shadows the GET /%s endpoint\n",
                         g_web_dir.c_str(), reserved, reserved);
@@ -828,6 +904,98 @@ int main(int argc, char** argv) {
         std::string body = "{\"status\":\"ok\",\"model\":\"" + g_variant + "\",\"encoding\":\"" +
                            g_encoding + "\",\"loaded\":" + (loaded ? "true" : "false") +
                            ",\"loudness_defaults\":" + loudness_params_json(sa3::loudness_defaults_from_env()) + "}";
+        res.set_content(body, "application/json");
+    });
+
+    svr.Get("/init-audio", [&aidir](const httplib::Request&, httplib::Response& res) {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+        const std::vector<InitAudioEntry> files = scan_init_audio(aidir);
+        std::string body = "{\"success\":true,\"files\":" + init_audio_json(files)
+                         + ",\"audio_in_dir\":\"" + json_escape(fs::absolute(aidir, ec).string())
+                         + "\",\"max_upload_bytes\":" + std::to_string((unsigned long long)k_max_upload_bytes) + "}";
+        res.set_content(body, "application/json");
+    });
+
+    // Streamed to disk under a temp name, then renamed. Never buffered whole in memory, so an
+    // oversized body is refused mid-stream rather than after the server has already allocated
+    // it, and a client that disconnects halfway leaves no half-file for /init-audio to list.
+    svr.Post("/init-audio/upload", [&aidir](const httplib::Request& req, httplib::Response& res,
+                                            const httplib::ContentReader& content_reader) {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+
+        // Cheap pre-check: refuse before reading a byte when the client declares an oversized body.
+        if (req.has_header("Content-Length")) {
+            const auto declared = std::strtoull(req.get_header_value("Content-Length").c_str(), nullptr, 10);
+            if (declared > k_max_upload_bytes + (1u << 20)) {   // + multipart framing slack
+                res.status = 413;
+                res.set_content("{\"success\":false,\"error\":\"upload exceeds max_upload_bytes\"}", "application/json");
+                return;
+            }
+        }
+        if (!fs::is_directory(aidir, ec)) {
+            fs::create_directories(aidir, ec);
+            if (ec) {
+                res.status = 500;
+                res.set_content("{\"success\":false,\"error\":\"cannot create audio-in dir\"}", "application/json");
+                return;
+            }
+        }
+
+        std::string name, reject;
+        fs::path tmp, dest;
+        std::ofstream ofs;
+        size_t written = 0;
+        bool too_large = false, write_failed = false;
+
+        content_reader(
+            [&](const httplib::FormData& file) -> bool {
+                if (file.name != "file") return false;          // ignore other parts
+                name = safe_upload_name(file.filename);
+                if (name.empty()) {
+                    reject = "filename must be a plain .wav name (got \"" + file.filename + "\")";
+                    return false;
+                }
+                dest = fs::path(aidir) / name;
+                tmp  = fs::path(aidir) / (name + ".part");
+                ofs.open(tmp, std::ios::binary | std::ios::trunc);
+                if (!ofs) { reject = "cannot write to audio-in dir"; return false; }
+                return true;
+            },
+            [&](const char* chunk, size_t chunk_len) -> bool {
+                if (!ofs.is_open()) return true;                // part we skipped
+                if (written + chunk_len > k_max_upload_bytes) { too_large = true; return false; }
+                ofs.write(chunk, (std::streamsize)chunk_len);
+                if (!ofs) { write_failed = true; return false; }
+                written += chunk_len;
+                return true;
+            });
+
+        if (ofs.is_open()) ofs.close();
+        auto discard = [&]{ if (!tmp.empty()) fs::remove(tmp, ec); };
+
+        if (!reject.empty())   { discard(); res.status = 400; res.set_content("{\"success\":false,\"error\":\"" + json_escape(reject) + "\"}", "application/json"); return; }
+        if (too_large)         { discard(); res.status = 413; res.set_content("{\"success\":false,\"error\":\"upload exceeds max_upload_bytes\"}", "application/json"); return; }
+        if (write_failed)      { discard(); res.status = 500; res.set_content("{\"success\":false,\"error\":\"write failed\"}", "application/json"); return; }
+        if (name.empty() || written == 0) { discard(); res.status = 400; res.set_content("{\"success\":false,\"error\":\"no file uploaded\"}", "application/json"); return; }
+
+        fs::rename(tmp, dest, ec);
+        if (ec) { discard(); res.status = 500; res.set_content("{\"success\":false,\"error\":\"cannot finalize upload\"}", "application/json"); return; }
+
+        // Belt and braces: the name is already reduced to a basename, but confirm the file
+        // really landed inside the pool before telling the caller where it is.
+        const fs::path resolved = fs::weakly_canonical(dest, ec);
+        const fs::path base     = fs::weakly_canonical(fs::path(aidir), ec);
+        if (ec || resolved.parent_path() != base) {
+            fs::remove(dest, ec);
+            res.status = 400;
+            res.set_content("{\"success\":false,\"error\":\"refused: resolved outside audio-in dir\"}", "application/json");
+            return;
+        }
+
+        std::string body = "{\"success\":true,\"name\":\"" + json_escape(name) + "\",\"path\":\""
+                         + json_escape(resolved.string()) + "\",\"bytes\":" + std::to_string((unsigned long long)written) + "}";
         res.set_content(body, "application/json");
     });
 
@@ -1047,8 +1215,8 @@ int main(int argc, char** argv) {
         res.set_content(body, "application/json");
     });
 
-    fprintf(stderr, "[sa3-server] http://%s:%d  model=%s/%s  models=%s  adapters=%s  source_loras=%s  prompts=%s  web=%s  (async /poll_status; frugal default)\n",
-            host.c_str(), port, g_variant.c_str(), g_encoding.c_str(), g_models_dir.c_str(), adir.c_str(), sldir.c_str(), pdir.c_str(),
+    fprintf(stderr, "[sa3-server] http://%s:%d  model=%s/%s  models=%s  adapters=%s  source_loras=%s  prompts=%s  audio_in=%s  web=%s  (async /poll_status; frugal default)\n",
+            host.c_str(), port, g_variant.c_str(), g_encoding.c_str(), g_models_dir.c_str(), adir.c_str(), sldir.c_str(), pdir.c_str(), aidir.c_str(),
             g_web_dir.empty() ? "(none)" : g_web_dir.c_str());
     if (!svr.listen(host.c_str(), port)) {
         fprintf(stderr, "[sa3-server] failed to bind %s:%d\n", host.c_str(), port);


### PR DESCRIPTION
Second half of #22. `/generate` takes `init_path`, a filesystem path, which is fine for a DAW
plug-in but impossible for a browser. These two are that bridge, ported from your `web-app`
branch:

```
GET  /init-audio         lists the pool
POST /init-audio/upload  puts a wav in it, returns the path to pass as init_path
```

The listing is the same directory scan `/loras` already does. I did rewrite the upload: it joined
the multipart filename straight onto the pool dir, and `fs::path(dir) / name` throws away `dir`
when `name` is absolute, so a filename of `C:/Windows/Temp/x.exe` wrote there. Now it takes bare
`.wav` names only (rejected rather than quietly renamed), caps at 256 MiB streamed to disk, and
warns at startup if the server is bound off loopback.

One open question in the comment below — it depends on how you serve the UI, so I didn't want to
guess.
