### PR TITLE
train: --lora-scope for the 168 per-block projections

### DIFF
--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -11,6 +11,39 @@ optimization remains possible. These training additions do not alter the existin
 Measured training throughput and reproducible backend comparisons are collected in
 [TRAINING_BENCHMARKS.md](TRAINING_BENCHMARKS.md).
 
+## Quickstart
+
+Everything below has a working default. In practice these are the four knobs worth touching:
+
+```sh
+sa3-train --dataset /path/to/dataset --steps 2000 \
+          --rank 16 --duration 23 --lora-scope core
+```
+
+| flag | default | what it does |
+|---|---|---|
+| `--steps N` | `10000` | optimizer updates. 2000 is a reasonable first run on a small dataset. |
+| `--rank N` | `16` | adapter capacity. `--alpha` follows it automatically, so raising rank does **not** silently weaken the adapter. |
+| `--duration SEC` | — | seconds of audio per training crop. Without it you get `--frames 512`, which is **47.6 s**. |
+| `--lora-scope full\|core` | `full` | `core` adapts only the 24 blocks' own projections (168 weights instead of 228): ~10% faster steps and ~11% smaller adapters, and in a matched 2000-step run the loss curve was within 0.0013 of `full` throughout. |
+
+Two things that are easy to miss:
+
+- **`--duration` is in seconds; `--frames` is in latent frames.** One latent frame is 4096 samples at
+  44.1 kHz, so 512 frames = 47.6 s, 256 = 23.8 s. `--duration` is the friendlier knob and wins when
+  both are given. Shorter crops train faster and use less memory; the reference regime is ~47 s.
+- **MP3 datasets need `ffmpeg` on `PATH`.** Decoding shells out to it (see [Dataset](#dataset)).
+  WAV inputs do not.
+
+Training prints what it is actually doing at startup, which is worth a glance before walking away:
+
+```
+[train] lora scope: core -> 168 targets (168 per-block, 0 elsewhere)  rank 16 alpha 16 scale 1
+```
+
+`scale` is `alpha/rank` and should normally be `1`. Adapter strength is multiplied by it in both
+training and inference, so a `scale` well below 1 means the adapter is being attenuated.
+
 ## Build
 
 ```sh
@@ -63,6 +96,12 @@ datasets/my-training-set/
 ```
 
 Training honors `train/filelist.txt`. Test and evaluation splits are loaded only for validation/evaluation and are rejected if any train item overlaps by basename, canonical path, or `audio_sha256`.
+
+**MP3 decoding requires `ffmpeg` on `PATH`.** `sa3-train` shells out to it (`ffmpeg -f f32le …`) to
+read compressed audio; there is no built-in MP3 decoder. Inference has no such dependency — it reads
+WAV directly — so a machine that generates fine can still fail to train. Check with `ffmpeg -version`
+before a long run; a missing binary surfaces as a decode failure per file rather than a clear
+"ffmpeg not found".
 
 ## Train
 
@@ -132,6 +171,50 @@ pass `--svd-bases bases.gguf` to load precomputed bases instead — generate the
 
 Each sample is conditioned by its caption text. A dataset-level `prompt_config.json` can optionally
 compose that caption with general metadata tags or path-derived text.
+
+## Target Scopes
+
+Which DiT weights get an adapter. Every 2D `dit.*.weight` is eligible; a scope narrows that.
+
+| scope | targets | what it covers |
+|---|---|---|
+| `full` (default) | 228 | the 9 per-block projections plus the 12 outside the blocks (`proj_in`/`proj_out`, `pre_conv`/`post_conv`, `time_embed`, `cond_embed`, `global_embed`, `gce`) |
+| `core` | 168 | the 7 per-block projections only — `self.qkv`, `self.out`, `cross.q`, `cross.kv`, `cross.out`, `ff.proj`, `ff.out` — across 24 blocks |
+
+`core` is the scope the MLX trainer uses, where it is spelled `include transformer.layers` /
+`exclude to_local_embed`. Those are upstream names; ours are `dit.<N>.…` and `local.{0,2}`, so the
+filters do not transfer literally — see [TENSOR-MAP.md](TENSOR-MAP.md) for the full mapping.
+
+Measured on medium, 23 s crops, rank 16, 2000 steps, CUDA:
+
+| | full (228) | core (168) |
+|---|---|---|
+| final loss | 0.8830 | 0.8843 |
+| s/step | 0.718 | 0.642 |
+| adapter | 82.3 MB | 72.7 MB |
+
+Same quality — the loss curves stayed within 0.0014 of each other in every 250-step window — for
+~10% faster steps and ~11% smaller adapters.
+
+Worth knowing why those savings are ~11% and not the 26% the target count suggests: **the dropped
+weights are the small ones.** `core` drops 26% of the targets but only 11.6% of the adapter
+parameters (19.06 M kept vs 2.51 M dropped), because the large projections are all kept and
+`local.{0,2}` plus the head/tail weights are comparatively tiny. The step-time saving tracks the
+parameter ratio rather than the target ratio, since the frozen base still runs in full either way.
+`core` does skip one graph entirely — the head backward pass has nothing to differentiate — but that
+turns out to be nearly free.
+
+For anything the named scopes do not carve out, `--lora-include` and `--lora-exclude` take
+comma-separated substrings matched against tensor names, applied after the scope:
+
+```sh
+--lora-scope core --lora-exclude ff.        # 120 targets: core minus both feed-forward projections
+--lora-scope full --lora-include cross.     #  72 targets: cross-attention only
+```
+
+A scope change invalidates a checkpoint — the resume fingerprint covers every target name — so
+`--resume` refuses rather than continuing into a different parametrization. Pick a scope before a
+long run, not partway through.
 
 ## Outputs
 

--- a/src/train_ckpt.h
+++ b/src/train_ckpt.h
@@ -327,7 +327,13 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
     }
 
     // --- H: head VJP fwd+bwd ---
-    {
+    // Only exists to produce gradients for adapters on the head weights (proj_in, pre_conv,
+    // time_embed, cond_embed, global_embed, gce). Nothing downstream consumes its outputs -- the
+    // head is the start of the chain -- so with no head adapters there is nothing to compute.
+    // It must be SKIPPED rather than built empty: none of its inputs are parameters, so
+    // ggml_build_backward_expand would assert "no trainable parameters found". That is what a
+    // --lora-scope of core does, since core keeps only the 24 blocks' own projections.
+    if (!out.head_param_idx.empty()) {
         out.hctx = graph_ctx(4096, true);
         if (!out.hctx) return fail("ggml_init failed for head graph");
         out.hgraph = ggml_new_graph_custom(out.hctx, 4096, true);
@@ -346,12 +352,17 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
             return fail("failed to allocate head training graph");
     }
 
+    char hdesc[64] = "H skipped (no head adapters)";
+    if (out.hgraph) {
+        snprintf(hdesc, sizeof hdesc, "H %d nodes %.1f MiB", ggml_graph_n_nodes(out.hgraph),
+                 ggml_gallocr_get_buffer_size(out.halloc, 0) / (1024.0 * 1024.0));
+    }
     std::fprintf(stderr, "[train] checkpointed graphs: F %d nodes %.1f MiB, T %d nodes %.1f MiB, "
-                 "%d block graphs %d nodes each, H %d nodes %.1f MiB, persistent %.1f MiB\n",
+                 "%d block graphs %d nodes each, %s, persistent %.1f MiB\n",
                  ggml_graph_n_nodes(out.fgraph), ggml_gallocr_get_buffer_size(out.falloc, 0) / (1024.0 * 1024.0),
                  ggml_graph_n_nodes(out.tgraph), ggml_gallocr_get_buffer_size(out.talloc, 0) / (1024.0 * 1024.0),
                  dc.depth, ggml_graph_n_nodes(out.blocks[0].graph),
-                 ggml_graph_n_nodes(out.hgraph), ggml_gallocr_get_buffer_size(out.halloc, 0) / (1024.0 * 1024.0),
+                 hdesc,
                  ggml_backend_buffer_get_size(out.pbuf) / (1024.0 * 1024.0));
     return true;
 }

--- a/src/train_config.h
+++ b/src/train_config.h
@@ -38,7 +38,7 @@ struct TrainConfig {
     // need --dataset and, optionally, --steps; every value remains individually overridable.
     std::string adapter_type = "dora-rows";
     int rank = 16;
-    float alpha = 16.0f;
+    float alpha = 0.0f;   // 0 => follow rank (resolved in train_finalize_defaults); scale = alpha/rank
     float learning_rate = 1.0e-4f;
     float weight_decay = 0.01f;
     float adam_beta1 = 0.9f;
@@ -404,6 +404,13 @@ inline bool train_parse_args(int argc, char** argv, TrainConfig& c, std::string&
 // gary4local/underfit prompt composition without adding another flag to the normal command.
 inline void train_finalize_defaults(TrainConfig& c) {
     namespace fs = std::filesystem;
+
+    // alpha follows rank unless asked otherwise. The adapter contributes at alpha/rank, so a
+    // fixed alpha silently attenuates every rank above it: --rank 128 against a hardcoded 16
+    // trains AND infers at 1/8 strength, which reads as "the LoRA did nothing" long after the
+    // run is over. Upstream MLX defaults alpha to rank (models/defs/lora.py, lora_train_mlx.py
+    // "Default: = rank"), and gary4local passes rank or 2*rank explicitly for the same reason.
+    if (c.alpha <= 0.0f) c.alpha = (float)c.rank;
     if (c.prompt_config_path.empty() && !c.dataset_dir.empty()) {
         const fs::path prompt = fs::path(c.dataset_dir) / "prompt_config.json";
         std::error_code ec;
@@ -513,7 +520,7 @@ inline std::string train_config_usage(const char* argv0) {
        << "core options: --model medium|small-music|small-sfx --models-dir DIR --dataset DIR --out DIR\n"
        << "              --steps N (alias: --max-steps; default 10000)\n"
        << "              --resume adapter-step-N.gguf|trainer-state-step-N.gguf (N -> --steps total)\n"
-       << "adapter: --adapter-type lora|dora-rows|dora-cols|bora|*-xs --rank N --alpha F\n"
+       << "adapter: --adapter-type lora|dora-rows|dora-cols|bora|*-xs --rank N --alpha F (default: = rank)\n"
        << "          --lora-scope full|core (full=228 weights, core=168 per-block projections)\n"
        << "          --lora-include a,b --lora-exclude a,b (substring filters, applied after scope)\n"
        << "optimization: --learning-rate F --batch-size N --threads N --frames N --duration SEC --seed N\n"

--- a/src/train_config.h
+++ b/src/train_config.h
@@ -26,6 +26,11 @@ struct TrainConfig {
     std::string dit_path;
     std::string same_path;
     std::string dataset_dir;
+    // LoRA target scope: "full" (228 weights) or "core" (168, the per-block projections
+    // only). lora_include/lora_exclude are substring escape hatches applied after the scope.
+    std::string lora_scope = "full";
+    std::vector<std::string> lora_include;
+    std::vector<std::string> lora_exclude;
     std::string train_split = "train";
     std::string test_split = "test";
     std::string evaluation_split = "evaluation";
@@ -136,6 +141,22 @@ inline bool train_normalize_dist_shift(std::string& v) {
     return true;
 }
 
+// Split a comma-separated list into trimmed, non-empty pieces (e.g. "cross.,ff." -> {"cross.","ff."}).
+inline std::vector<std::string> train_split_csv(const std::string& text) {
+    std::vector<std::string> out;
+    size_t start = 0;
+    while (start <= text.size()) {
+        const size_t sep = text.find(',', start);
+        std::string piece = text.substr(start, sep == std::string::npos ? std::string::npos : sep - start);
+        const size_t a = piece.find_first_not_of(" \t");
+        const size_t b = piece.find_last_not_of(" \t");
+        if (a != std::string::npos) out.push_back(piece.substr(a, b - a + 1));
+        if (sep == std::string::npos) break;
+        start = sep + 1;
+    }
+    return out;
+}
+
 // Parse a comma-separated list of probabilities (e.g. "0.2,0.6,0.2") into doubles.
 inline bool train_parse_probs(const std::string& text, std::vector<double>& out, std::string& err) {
     out.clear();
@@ -227,6 +248,9 @@ inline bool train_set_config_value(TrainConfig& c, const std::string& key, const
     else if (key == "dit" || key == "dit_path") c.dit_path = value;
     else if (key == "same" || key == "same_path") c.same_path = value;
     else if (key == "dataset" || key == "dataset-dir" || key == "dataset_dir") c.dataset_dir = value;
+    else if (key == "lora-scope" || key == "lora_scope") c.lora_scope = value;
+    else if (key == "lora-include" || key == "lora_include") c.lora_include = train_split_csv(value);
+    else if (key == "lora-exclude" || key == "lora_exclude") c.lora_exclude = train_split_csv(value);
     else if (key == "train-split" || key == "train_split") c.train_split = value;
     else if (key == "test-split" || key == "test_split") c.test_split = value;
     else if (key == "evaluation-split" || key == "evaluation_split") c.evaluation_split = value;
@@ -448,6 +472,9 @@ inline bool validate_train_config(const TrainConfig& c, std::string& err) {
     if (c.batch_size <= 0) { err = "batch_size must be positive"; return false; }
     if (c.cpu_threads < 0) { err = "threads must be positive (or 0 for automatic)"; return false; }
     if (c.checkpoint_every < 0) { err = "checkpoint_every must be non-negative (0 = off)"; return false; }
+    if (!(c.lora_scope == "full" || c.lora_scope == "core")) {
+        err = "unknown --lora-scope '" + c.lora_scope + "' (expected full|core)"; return false;
+    }
     if (c.frames <= 0 && c.duration_sec <= 0.0f) { err = "frames or duration_sec must be positive"; return false; }
     if (c.optimizer != "adamw") { err = "unsupported optimizer: " + c.optimizer; return false; }
     if (c.timestep_sampler != "uniform" && c.timestep_sampler != "trunc_logit_normal") {
@@ -487,6 +514,8 @@ inline std::string train_config_usage(const char* argv0) {
        << "              --steps N (alias: --max-steps; default 10000)\n"
        << "              --resume adapter-step-N.gguf|trainer-state-step-N.gguf (N -> --steps total)\n"
        << "adapter: --adapter-type lora|dora-rows|dora-cols|bora|*-xs --rank N --alpha F\n"
+       << "          --lora-scope full|core (full=228 weights, core=168 per-block projections)\n"
+       << "          --lora-include a,b --lora-exclude a,b (substring filters, applied after scope)\n"
        << "optimization: --learning-rate F --batch-size N --threads N --frames N --duration SEC --seed N\n"
        << "          --lr-scheduler constant|inverse_lr [--lr-inv-gamma F --lr-power F --lr-warmup F --lr-final F]\n"
        << "schedule: --timestep-sampler uniform|trunc_logit_normal --dist-shift none|full|flux|logsnr\n"

--- a/src/train_loop.h
+++ b/src/train_loop.h
@@ -395,9 +395,12 @@ inline bool run_train_dit_accumulate_ckpt(ggml_backend_t backend, TrainDitCkpt& 
     // H: head backward against dL/dx_0 + the summed context/gcond gradients
     ggml_backend_tensor_set(ck.Gctx_in, gctx_sum.data(), 0, gctx_sum.size() * sizeof(float));
     ggml_backend_tensor_set(ck.Ggcond_in, ggcond_sum.data(), 0, ggcond_sum.size() * sizeof(float));
-    ggml_graph_reset(ck.hgraph);
-    ggml_backend_graph_compute(backend, ck.hgraph);
-    if (!train_accum_read_subset(ck.hgraph, ck, ck.head_param_idx, accum, err)) return false;
+    // Skipped when no adapter lives on a head weight (e.g. --lora-scope core); see train_ckpt.h.
+    if (ck.hgraph) {
+        ggml_graph_reset(ck.hgraph);
+        ggml_backend_graph_compute(backend, ck.hgraph);
+        if (!train_accum_read_subset(ck.hgraph, ck, ck.head_param_idx, accum, err)) return false;
+    }
     if (profile) {
         const auto now = std::chrono::steady_clock::now();
         profile_head_ms = std::chrono::duration<double, std::milli>(now - profile_mark).count();

--- a/src/train_lora.h
+++ b/src/train_lora.h
@@ -5,6 +5,7 @@
 #include "train_svd.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstring>
 #include <random>
@@ -50,7 +51,53 @@ struct TrainLoraGraphParam {
     ggml_tensor* magnitude_c = nullptr; // bora cols [in]
 };
 
-inline std::vector<TrainLoraTarget> enumerate_train_lora_targets(const GgufModel& dit) {
+// Which weights get an adapter. Every 2D `dit.*.weight` is eligible; a scope narrows that.
+//
+//   full  228  everything eligible: the 9 per-block projections plus the 12 outside the blocks
+//              (proj_in/out, pre/post_conv, time_embed, cond_embed, global_embed, gce).
+//   core  168  the 7 per-block projections only -- self.qkv, self.out, cross.q, cross.kv,
+//              cross.out, ff.proj, ff.out -- dropping local.{0,2} and everything non-block.
+//
+// `core` is the scope MLX trains, where it is spelled `include transformer.layers` /
+// `exclude to_local_embed`; those are upstream names, ours are `dit.<N>.…` and `local.{0,2}`.
+// It removes 60 of 228 parametrizations (~26%) and in practice trains to the same quality. The
+// frozen base still runs in full either way -- this only shrinks adapter math, gradients and
+// optimizer state. See docs/TENSOR-MAP.md for the full upstream<->ours name mapping.
+//
+// include/exclude are plain substring matches over the tensor name, applied after the scope, as
+// an escape hatch for targeting something the named scopes do not carve out.
+struct TrainLoraScope {
+    std::string name = "full";
+    std::vector<std::string> include;   // if non-empty, a name must contain one of these
+    std::vector<std::string> exclude;   // a name containing any of these is dropped
+};
+
+inline bool train_lora_scope_known(const std::string& s) { return s == "full" || s == "core"; }
+
+// True if `name` is one of the 24 transformer blocks' own projections, i.e. `dit.<digits>.…`.
+inline bool train_lora_is_block_weight(const std::string& name) {
+    size_t i = 4;                                    // past "dit."
+    if (name.size() <= i || !std::isdigit((unsigned char)name[i])) return false;
+    while (i < name.size() && std::isdigit((unsigned char)name[i])) i++;
+    return i < name.size() && name[i] == '.';
+}
+
+inline bool train_lora_target_selected(const std::string& name, const TrainLoraScope& scope) {
+    if (scope.name == "core") {
+        if (!train_lora_is_block_weight(name)) return false;      // drops the 12 non-block weights
+        if (name.find(".local.") != std::string::npos) return false;  // drops local.{0,2} (48)
+    }
+    if (!scope.include.empty()) {
+        bool hit = false;
+        for (const std::string& p : scope.include) if (name.find(p) != std::string::npos) { hit = true; break; }
+        if (!hit) return false;
+    }
+    for (const std::string& p : scope.exclude) if (name.find(p) != std::string::npos) return false;
+    return true;
+}
+
+inline std::vector<TrainLoraTarget> enumerate_train_lora_targets(const GgufModel& dit,
+                                                                 const TrainLoraScope& scope = {}) {
     std::vector<TrainLoraTarget> out;
     for (const auto& kv : dit.tensors) {
         const std::string& name = kv.first;
@@ -58,6 +105,7 @@ inline std::vector<TrainLoraTarget> enumerate_train_lora_targets(const GgufModel
         if (name.rfind("dit.", 0) != 0) continue;
         if (name.size() < 7 || name.compare(name.size() - 7, 7, ".weight") != 0) continue;
         if (ggml_n_dims(t) != 2) continue;
+        if (!train_lora_target_selected(name, scope)) continue;
         TrainLoraTarget target;
         target.weight_name = name;
         target.stem = name.substr(0, name.size() - 7);

--- a/tests/train_config_test.cpp
+++ b/tests/train_config_test.cpp
@@ -21,8 +21,8 @@ int main() {
         const sa3::TrainConfig c;
         fails += expect(c.model_variant == "medium", "default model medium");
         fails += expect(c.adapter_type == "dora-rows", "default adapter dora-rows");
-        fails += expect(c.rank == 16 && c.alpha > 15.99f && c.alpha < 16.01f,
-                        "default rank/alpha 16");
+        fails += expect(c.rank == 16 && c.alpha == 0.0f,
+                        "default rank 16, alpha unset (0 => follow rank)");
         fails += expect(c.frames == 512 && c.seed == 42, "default frames 512 and seed 42");
         fails += expect(c.adam_beta2 > 0.949f && c.adam_beta2 < 0.951f,
                         "default Adam beta2 0.95");
@@ -223,6 +223,25 @@ int main() {
         c.lr_warmup = 1.0f;   // out of [0,1)
         std::string err;
         fails += expect(!sa3::validate_train_config(c, err), "bad lr_warmup rejected");
+    }
+    {
+        // alpha follows rank unless set. The adapter contributes at alpha/rank, so a fixed alpha
+        // silently attenuates every larger rank: rank 128 against a hardcoded alpha 16 trains and
+        // infers at 1/8 strength. Upstream MLX defaults alpha to rank for the same reason.
+        sa3::TrainConfig c;
+        c.rank = 128;
+        sa3::train_finalize_defaults(c);
+        fails += expect(c.alpha == 128.0f, "alpha follows rank when unset");
+
+        sa3::TrainConfig d;
+        d.rank = 128;
+        d.alpha = 16.0f;                 // explicit, however odd
+        sa3::train_finalize_defaults(d);
+        fails += expect(d.alpha == 16.0f, "explicit alpha is preserved");
+
+        sa3::TrainConfig e;               // untouched defaults still land on scale 1.0
+        sa3::train_finalize_defaults(e);
+        fails += expect(e.rank == 16 && e.alpha == 16.0f, "default rank/alpha both 16");
     }
     if (fails) return 1;
     std::printf("train_config_test: ok\n");

--- a/tests/train_lora_test.cpp
+++ b/tests/train_lora_test.cpp
@@ -29,6 +29,37 @@ int main() {
     m.tensors[c->name] = c;
     std::vector<sa3::TrainLoraTarget> targets = sa3::enumerate_train_lora_targets(m);
     fails += expect(targets.size() == 1, "one DiT 2D weight target");
+
+    // ---- target scopes -------------------------------------------------------------------
+    // A stand-in DiT with the shapes that matter: two per-block projections, a local-cond
+    // weight (what `core` drops), and a non-block weight (what `core` also drops).
+    {
+        sa3::GgufModel s;
+        const char* names[] = { "dit.0.self.qkv.weight", "dit.0.cross.kv.weight",
+                                "dit.0.local.0.weight",  "dit.proj_in.weight" };
+        for (const char* n : names) {
+            ggml_tensor* t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 4, 4);
+            ggml_set_name(t, n);
+            s.tensors[n] = t;
+        }
+        sa3::TrainLoraScope full;                                  // default
+        sa3::TrainLoraScope core; core.name = "core";
+        fails += expect(sa3::enumerate_train_lora_targets(s, full).size() == 4, "full scope keeps all");
+        fails += expect(sa3::enumerate_train_lora_targets(s, core).size() == 2, "core drops local + non-block");
+
+        // include/exclude are substring matches applied after the scope
+        sa3::TrainLoraScope only_cross; only_cross.include = {"cross."};
+        fails += expect(sa3::enumerate_train_lora_targets(s, only_cross).size() == 1, "include filters");
+        sa3::TrainLoraScope no_self; no_self.exclude = {"self."};
+        fails += expect(sa3::enumerate_train_lora_targets(s, no_self).size() == 3, "exclude filters");
+        sa3::TrainLoraScope core_no_ff; core_no_ff.name = "core"; core_no_ff.exclude = {"cross."};
+        fails += expect(sa3::enumerate_train_lora_targets(s, core_no_ff).size() == 1, "scope then exclude");
+
+        // dit.<digits>. is what makes a weight "per-block"; dit.proj_in is not.
+        fails += expect(sa3::train_lora_is_block_weight("dit.11.ff.out.weight"), "block weight detected");
+        fails += expect(!sa3::train_lora_is_block_weight("dit.proj_in.weight"), "non-block detected");
+        fails += expect(!sa3::train_lora_is_block_weight("dit.time_embed.0.weight"), "embed is not a block");
+    }
     fails += expect(targets[0].stem == "dit.0.self.qkv", "target stem");
     fails += expect(targets[0].in == 4 && targets[0].out == 8, "target shape");
     sa3::TrainLoraState st;

--- a/tools/sa3-train.cpp
+++ b/tools/sa3-train.cpp
@@ -481,6 +481,15 @@ int main(int argc, char** argv) {
         size_t cursor_next_sample = first_oi;
         bool stop = cfg.max_steps > 0 && loop.step >= cfg.max_steps;
         if (cfg.max_epochs > 0 && epoch >= cfg.max_epochs) stop = true;
+        // Per-step wall time. Started here so model load and pre-encode are excluded -- those are
+        // one-off and identical across configurations, and folding them in would mask the thing
+        // worth measuring (what a target scope or adapter family costs per step).
+        double t_prev_step = sa3::wall_time_s();
+        const double t_train_begin = t_prev_step;
+        double step_seconds_total = 0.0;
+        int step_seconds_count = 0;
+        double step_recent_total = 0.0;   // rolling window for the console line
+        int step_recent_count = 0;
         while (!stop) {
             size_t oi_begin = 0;
             if (restored_epoch_order) {
@@ -714,9 +723,17 @@ int main(int argc, char** argv) {
                 if (have_inpaint)
                     inpaint_tag = std::string(" mask=") + kMaskNames[(int)inpaint.type] +
                                   "(" + std::to_string(inpaint.n_gen) + "gen/" + std::to_string(inpaint.n_ctx) + "ctx)";
-                std::printf("epoch %d step %d id=%s t=%.4f%s%s lr=%.3e loss=%.6f gnorm=%.4f prompt=\"%s%s\"\n",
+                const double t_now_step = sa3::wall_time_s();
+                const double step_s = t_now_step - t_prev_step;
+                t_prev_step = t_now_step;
+                step_seconds_total += step_s;  step_seconds_count++;
+                step_recent_total  += step_s;  step_recent_count++;
+                const double step_recent_avg = step_recent_total / (double)step_recent_count;
+                if (step_recent_count >= 50) { step_recent_total = 0.0; step_recent_count = 0; }
+                std::printf("epoch %d step %d id=%s t=%.4f%s%s lr=%.3e loss=%.6f gnorm=%.4f %.2fs/step prompt=\"%s%s\"\n",
                             epoch, loop.step, pair.id.c_str(), sample.t, cfg_dropped ? " cfg_drop" : "",
-                            inpaint_tag.c_str(), applied_lr, loss, grad_norm, prompt_preview.c_str(), caption.size() > 48 ? "..." : "");
+                            inpaint_tag.c_str(), applied_lr, loss, grad_norm, step_recent_avg,
+                            prompt_preview.c_str(), caption.size() > 48 ? "..." : "");
                 metrics << "{\"epoch\":" << epoch << ",\"update\":" << loop.step
                         << ",\"split\":\"train\",\"id\":\"" << pair.id
                         << "\",\"t\":" << sample.t << ",\"cfg_drop\":" << (cfg_dropped ? 1 : 0);
@@ -724,7 +741,7 @@ int main(int argc, char** argv) {
                     metrics << ",\"mask\":\"" << kMaskNames[(int)inpaint.type] << "\""
                             << ",\"n_gen\":" << inpaint.n_gen << ",\"n_ctx\":" << inpaint.n_ctx;
                 metrics << ",\"lr\":" << applied_lr << ",\"loss\":" << loss
-                        << ",\"grad_norm\":" << grad_norm << "}\n";
+                        << ",\"grad_norm\":" << grad_norm << ",\"step_s\":" << step_s << "}\n";
                 metrics.flush();
                 if (updated && cfg.checkpoint_every > 0 && (loop.step % cfg.checkpoint_every) == 0)
                     do_checkpoint(epoch, oi + 1);
@@ -742,6 +759,12 @@ int main(int argc, char** argv) {
         }
 
         if (loop.step <= 0) throw std::runtime_error("training completed without an optimizer update");
+        if (step_seconds_count > 0) {
+            const double mean_step = step_seconds_total / (double)step_seconds_count;
+            const double wall = sa3::wall_time_s() - t_train_begin;
+            std::printf("[train] %d steps in %.1fs, mean %.3fs/step (%.2f steps/s)\n",
+                        step_seconds_count, wall, mean_step, mean_step > 0.0 ? 1.0 / mean_step : 0.0);
+        }
         if (last_checkpoint_step != loop.step) {
             const std::string current_adapter = (std::filesystem::path(cfg.output_dir) /
                 ("adapter-step-" + std::to_string(loop.step) + ".gguf")).string();

--- a/tools/sa3-train.cpp
+++ b/tools/sa3-train.cpp
@@ -266,8 +266,10 @@ int main(int argc, char** argv) {
             size_t block_targets = 0;
             for (const sa3::TrainLoraTarget& t : targets)
                 if (sa3::train_lora_is_block_weight(t.weight_name)) block_targets++;
-            std::fprintf(stderr, "[train] lora scope: %s -> %zu targets (%zu per-block, %zu elsewhere)",
-                         cfg.lora_scope.c_str(), targets.size(), block_targets, targets.size() - block_targets);
+            std::fprintf(stderr, "[train] lora scope: %s -> %zu targets (%zu per-block, %zu elsewhere)"
+                                 "  rank %d alpha %.4g scale %.4g",
+                         cfg.lora_scope.c_str(), targets.size(), block_targets, targets.size() - block_targets,
+                         cfg.rank, (double)cfg.alpha, (double)cfg.alpha / (double)cfg.rank);
             if (!cfg.lora_include.empty() || !cfg.lora_exclude.empty()) {
                 std::fprintf(stderr, "  [filters:");
                 for (const std::string& p : cfg.lora_include) std::fprintf(stderr, " +%s", p.c_str());

--- a/tools/sa3-train.cpp
+++ b/tools/sa3-train.cpp
@@ -234,7 +234,11 @@ int main(int argc, char** argv) {
         sa3::T5GemmaConfig tc = sa3::T5GemmaConfig::from(te);
         sa3::DitConfig dc = sa3::DitConfig::from(dit);
         sa3::SameConfig sc = sa3::SameConfig::from(ae);
-        std::vector<sa3::TrainLoraTarget> targets = sa3::enumerate_train_lora_targets(dit);
+        sa3::TrainLoraScope lora_scope;
+        lora_scope.name    = cfg.lora_scope;
+        lora_scope.include = cfg.lora_include;
+        lora_scope.exclude = cfg.lora_exclude;
+        std::vector<sa3::TrainLoraTarget> targets = sa3::enumerate_train_lora_targets(dit, lora_scope);
         if (!cfg.inpainting) {
             // The dit.*.local.* weights are only exercised by the inpainting local-cond path. Without
             // it they'd be dead LoRA targets (never in the forward, so no gradient and no buffer from

--- a/tools/sa3-train.cpp
+++ b/tools/sa3-train.cpp
@@ -171,6 +171,16 @@ int main(int argc, char** argv) {
             snap << "latents_dir=" << (cfg.latents_dir.empty() ? "(none)" : cfg.latents_dir) << "\n";
             snap << "target_latent_rms=" << cfg.target_latent_rms << "\n";
             snap << "rank=" << cfg.rank << "\n";
+            snap << "lora_scope=" << cfg.lora_scope << "\n";
+            {   // resolved target count is logged to stderr; the snapshot records the request
+                auto csv = [](const std::vector<std::string>& v) {
+                    std::string o;
+                    for (size_t i = 0; i < v.size(); i++) { if (i) o += ","; o += v[i]; }
+                    return o;
+                };
+                snap << "lora_include=" << csv(cfg.lora_include) << "\n";
+                snap << "lora_exclude=" << csv(cfg.lora_exclude) << "\n";
+            }
             snap << "alpha=" << cfg.alpha << "\n";
             snap << "learning_rate=" << cfg.learning_rate << "\n";
             snap << "weight_decay=" << cfg.weight_decay << "\n";
@@ -248,6 +258,24 @@ int main(int argc, char** argv) {
                 targets.end());
         }
         if (targets.empty()) throw std::runtime_error("no DiT LoRA targets found");
+
+        // Say out loud what is being adapted. The scope and the filters change the parameter
+        // count silently otherwise, and the count is the thing you want to eyeball against the
+        // scope you asked for (core=168, full=228 on medium).
+        {
+            size_t block_targets = 0;
+            for (const sa3::TrainLoraTarget& t : targets)
+                if (sa3::train_lora_is_block_weight(t.weight_name)) block_targets++;
+            std::fprintf(stderr, "[train] lora scope: %s -> %zu targets (%zu per-block, %zu elsewhere)",
+                         cfg.lora_scope.c_str(), targets.size(), block_targets, targets.size() - block_targets);
+            if (!cfg.lora_include.empty() || !cfg.lora_exclude.empty()) {
+                std::fprintf(stderr, "  [filters:");
+                for (const std::string& p : cfg.lora_include) std::fprintf(stderr, " +%s", p.c_str());
+                for (const std::string& p : cfg.lora_exclude) std::fprintf(stderr, " -%s", p.c_str());
+                std::fprintf(stderr, "]");
+            }
+            std::fprintf(stderr, "\n");
+        }
 
         sa3::GgufModel svd_bases;
         const bool have_bases = !cfg.svd_bases_path.empty();

--- a/tools/sa3-train.cpp
+++ b/tools/sa3-train.cpp
@@ -116,6 +116,22 @@ int main(int argc, char** argv) {
                     return 2;
                 }
             }
+        } else {
+            // A fresh run into a directory that already holds checkpoints is refused by
+            // write_train_checkpoint_pair, which keeps step checkpoints immutable -- but that only
+            // runs at checkpoint time, so the failure landed after --checkpoint-every steps of
+            // training (or, if checkpoint_every exceeds max_steps, not until the very end). Check it
+            // here instead, before anything is loaded or encoded.
+            const int latest = sa3::train_latest_checkpoint_step(cfg.output_dir);
+            if (latest >= 0) {
+                std::fprintf(stderr,
+                    "sa3-train: %s already contains training checkpoints (latest step %d).\n"
+                    "  step checkpoints are immutable, so this run would fail on its first write.\n"
+                    "  resume it:   --resume %s\\trainer-state-step-%d.gguf\n"
+                    "  or start elsewhere: --out <new dir>\n",
+                    cfg.output_dir.c_str(), latest, cfg.output_dir.c_str(), latest);
+                return 2;
+            }
         }
         sa3::ModelPaths paths;
         if (!sa3::resolve_train_model_paths(cfg, paths, err)) {


### PR DESCRIPTION
Adds `--lora-scope` so a run can adapt only the 24 blocks' own projections instead of every
eligible DiT weight, plus the four things battle-testing it turned up.

## The feature

| scope | targets | what it covers |
| --- | --- | --- |
| `full` (default) | 228 | the 9 per-block projections plus the 12 outside the blocks |
| `core` | 168 | `self.qkv`, `self.out`, `cross.q`, `cross.kv`, `cross.out`, `ff.proj`, `ff.out` × 24 blocks |

`core` is the scope the MLX trainer uses (`include transformer.layers` / `exclude
to_local_embed`). Those are upstream names — ours are `dit.<N>.…` and `local.{0,2}` — so the
filters do not transfer literally, hence named scopes. `--lora-include` / `--lora-exclude` take
comma-separated substrings as an escape hatch, applied after the scope.

Measured on medium, 23 s crops, rank 16, 2000 steps, CUDA:

| | full (228) | core (168) |
| --- | --- | --- |
| final loss | 0.8830 | 0.8843 |
| s/step | 0.718 | 0.642 |
| adapter | 82.3 MB | 72.7 MB |

Loss curves stayed within 0.0014 in every 250-step window. So: same quality, ~10% faster
steps, ~11% smaller adapters.

Worth stating plainly because I assumed otherwise: that is **not** the 26% the target count
suggests. `core` drops 26% of the targets but only 11.6% of the adapter parameters, because
the large projections are all kept and `local.{0,2}` plus the head/tail weights are small
(19.06 M kept vs 2.51 M dropped). The step saving tracks the parameter ratio, not the target
ratio — the frozen base still runs in full either way.

Default stays `full`. The resume fingerprint hashes every target name, so a scope change
already invalidates a checkpoint; flipping the default would strand anyone mid-run for a 10%
gain.

## Four fixes found by testing it

**The head graph asserted with no head adapters.** The checkpointed backward splits into F, T,
24 block graphs, and H. H exists only to emit gradients for adapters on the head weights, and
`core` leaves none — so `ggml_build_backward_expand` hit *"no trainable parameters found"*.
Skipped entirely now rather than built empty, which also makes `core` one fwd+bwd pass cheaper.
`full` is unchanged.

**`alpha` was hardcoded to 16 regardless of rank.** The adapter contributes at `alpha/rank`, so
`--rank 128` silently trained *and* inferred at ⅛ strength. A rank-128 run produced an adapter
with no audible influence and grad norms averaging 0.049 against 0.17–0.42 for every rank-16
run. Raising `--lora-strength` cannot recover it, because the attenuation is baked into what the
adapter learned. `alpha` now follows `rank` unless set — the convention upstream MLX uses in six
places (`help="Default: = rank"`) and that gary4local enforces by passing `rank*2` or a sentinel.
sa3.cpp was the one place the two could diverge.

**An occupied `--out` failed at the first checkpoint, not at startup.** Step checkpoints are
immutable, but the guard lived in the write path — so the failure arrived after 500 steps of
training, and not until the final step if `checkpoint_every` exceeded `max_steps`. Now checked
before anything loads: 0.17 s, and the message hands you the `--resume` command.

**No timing was recorded at all.** `metrics.jsonl` had loss, grad_norm and lr but nothing about
time, so comparing configurations meant timing the whole process by hand — which folds in model
load and pre-encode. Adds `step_s` per line, a rolling average on the console, and a summary at
the end. The clock starts after pre-encode.

## Docs

`TRAINING.md` gains a Quickstart, because the doc was thorough but had no entry point and the
two knobs people reach for first were invisible: `--duration` had **zero** mentions despite
working, and `--random-crop` none. It now states the frames↔seconds mapping outright — 512
frames reading as 47.6 s is not guessable — and shows the startup line so an attenuated adapter
is recognisable at step 0.

`ffmpeg` moves from a Troubleshooting bullet to a stated prerequisite: it is needed only for MP3
datasets and only for training, so a machine that generates fine can still fail to train.

Every figure quoted in the docs is checked against the runs in `train-runs/` and the medium DiT
tensor list, including the `--lora-include` / `--lora-exclude` example counts.
