### PR TITLE
train: all eight adapter families train, and 25x faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ what's next:
 > dora-cols and the -xs variants are formula-validated only (no trained checkpoint to a/b yet) but
 > share the same apply path.
 >
-> **training an adapter here** covers all eight, at 0.5–3.3 s/step on a laptop 5070 (medium, rank
-> 16, 128 frames) — roughly one to two hours for a 2000-step run at the reference 512 frames. see
-> [docs/TRAINING.md](docs/TRAINING.md).
+> **training an adapter here** covers all eight, at 0.8–2.5 s/step on a laptop 5070 (medium, rank
+> 16, the reference 512 frames) — a 2000-step run measured 34 min for dora-rows and 64 min for
+> dora-cols. see [docs/TRAINING.md](docs/TRAINING.md).
 
 credits:
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ what's next:
 > dora-cols and the -xs variants are formula-validated only (no trained checkpoint to a/b yet) but
 > share the same apply path.
 >
-> **training an adapter here** covers six of the eight. dora-cols and dora-cols-xs currently abort in
-> the backward pass, and the bora families train correctly but ~110x slower per step than lora, so a
-> full run takes over a day. see [docs/TRAINING.md](docs/TRAINING.md).
+> **training an adapter here** covers all eight, at 0.5–3.3 s/step on a laptop 5070 (medium, rank
+> 16, 128 frames) — roughly one to two hours for a 2000-step run at the reference 512 frames. see
+> [docs/TRAINING.md](docs/TRAINING.md).
 
 credits:
 

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -169,28 +169,37 @@ pass `--svd-bases bases.gguf` to load precomputed bases instead — generate the
 `python tools/compute_svd_bases.py --dit models/... --rank 8 --out bases.gguf` for exact
 `torch.linalg.svd` parity with the reference implementation.
 
-Accepted is not the same as working. Six of the eight train today; the two column-normalizing
-families do not:
+All eight train, and all eight are within a small factor of each other per step:
 
-| adapter type | trains | s/step |
-|---|---|---|
-| `lora` | yes | 0.5 |
-| `dora-rows` (default) | yes | 3.2 |
-| `lora-xs` | yes | 16.3 |
-| `dora-rows-xs` | yes | 30.9 |
-| `bora` | yes | 59.4 |
-| `bora-xs` | yes | 69.6 |
-| `dora-cols` | **no** | — |
-| `dora-cols-xs` | **no** | — |
+| adapter type | s/step (128 frames) |
+|---|---|
+| `lora` | 0.48 |
+| `lora-xs` | 0.71 |
+| `dora-rows-xs` | 1.24 |
+| `dora-cols-xs` | 1.42 |
+| `dora-cols` | 1.61 |
+| `bora-xs` | 1.97 |
+| `bora` | 2.17 |
+| `dora-rows` (default) | 3.30 |
 
-`dora-cols` and `dora-cols-xs` abort during the backward pass with
-`GGML_ASSERT(ggml_is_padded_1d(a))` in `ggml_build_backward_expand`, which correlates with the
-column normalization those two share.
+CUDA / RTX 5070 Laptop, medium, rank 16 — ratios rather than absolutes. At the reference 512
+frames a 2000-step run is roughly one to two hours for any family.
 
-Timings are CUDA / RTX 5070 Laptop, medium, 128 frames, and are meant as ratios rather than
-absolutes. The spread matters when planning a run: `dora-rows` at 3.2 s/step is a couple of hours
-for 2000 steps, while `bora-xs` at 69.6 s/step is closer to a day and a half for the same
-schedule. `dora-rows` is the default and by far the best-trodden path.
+Two things used to make this table much worse, both fixed:
+
+- `dora-cols` and `dora-cols-xs` aborted during the backward pass on
+  `GGML_ASSERT(ggml_is_padded_1d(a))`. ggml differentiates transpose into a non-contiguous view
+  and `ggml_scale` rejects one, so the column-norm helper's transposed gradient reached the
+  scale on the low-rank delta. It now interposes a `cont`, whose backward re-materializes the
+  gradient contiguously.
+- Six of the eight ran an unbatched monolithic backward asking for 24.6 GiB of allocator on an
+  8 GiB card, so the driver paged it to system RAM: `dora-cols` measured 92.76 s/step at 512
+  frames against 2.05 now. Gradient checkpointing had been gated to the two families
+  `dit_lin` can apply functionally; the rest now build their effective weight inside whichever
+  segment graph consumes it, so they are checkpointed too. See `--checkpoint-backward`.
+
+`dora-rows` remains the default and the best-trodden path, and is now the slowest of the eight —
+the functional application costs more per step than materialized-plus-checkpointed at this size.
 
 Each sample is conditioned by its caption text. A dataset-level `prompt_config.json` can optionally
 compose that caption with general metadata tags or path-derived text.

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -208,6 +208,35 @@ Two things used to make this table much worse, both fixed:
 Each sample is conditioned by its caption text. A dataset-level `prompt_config.json` can optionally
 compose that caption with general metadata tags or path-derived text.
 
+### Path-derived captions are off by default
+
+`use_paths` defaults to **false**, which is a deliberate departure from underfit, where filenames
+are part of the dice pool. Turn it on only if your filenames actually read as descriptions of the
+music:
+
+```json
+{ "prompt_config": { "use_tags": true, "use_paths": true, "balance": { "tags": 40, "paths": 30 } } }
+```
+
+With that on, roughly a third of steps train on the file path verbatim — and `path_hide_ext`,
+`path_hide_dirs` and `path_hide_topmost` all default to false, so a track lands in the model as
+
+```
+03 - Gettysburg [Q-gtqz_il-w].wav
+```
+
+A track number, a YouTube ID and a file extension are not a description of a piece of music, and
+training on them teaches the adapter to emit your material in response to noise. That dilutes the
+conditioning the rest of the run is trying to build, and it shows up at inference as an adapter
+that responds best to no prompt at all rather than to a prompt from its training distribution.
+
+If your filenames are genuinely descriptive, `use_paths` is worth having, and `hide_ext` /
+`hide_dirs` / `hide_topmost_dir` trim the parts that are not. Otherwise leave it off and let the
+tags plus the CFG dropout (`--cfg-dropout-prob`, default 0.1) do the generalizing.
+
+Check what a run is actually training on before committing hours to it — the per-step log prints
+the composed caption, and a quick tally of `prompt="..."` across the log will show the mix.
+
 ## Target Scopes
 
 Which DiT weights get an adapter. Every 2D `dit.*.weight` is eligible; a scope narrows that.

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -169,21 +169,26 @@ pass `--svd-bases bases.gguf` to load precomputed bases instead — generate the
 `python tools/compute_svd_bases.py --dit models/... --rank 8 --out bases.gguf` for exact
 `torch.linalg.svd` parity with the reference implementation.
 
-All eight train, and all eight are within a small factor of each other per step:
+All eight train, and all eight are within about 3x of each other per step:
 
-| adapter type | s/step (128 frames) |
-|---|---|
-| `lora` | 0.48 |
-| `lora-xs` | 0.71 |
-| `dora-rows-xs` | 1.24 |
-| `dora-cols-xs` | 1.42 |
-| `dora-cols` | 1.61 |
-| `bora-xs` | 1.97 |
-| `bora` | 2.17 |
-| `dora-rows` (default) | 3.30 |
+| adapter type | s/step | first step |
+|---|---|---|
+| `lora` | 0.80 | 1.02 |
+| `lora-xs` | 1.05 | 1.33 |
+| `dora-rows` (default) | 1.25 | 6.17 |
+| `dora-rows-xs` | 1.57 | 2.00 |
+| `dora-cols-xs` | 1.84 | 2.31 |
+| `dora-cols` | 1.95 | 2.35 |
+| `bora-xs` | 2.33 | 2.67 |
+| `bora` | 2.47 | 2.88 |
 
-CUDA / RTX 5070 Laptop, medium, rank 16 — ratios rather than absolutes. At the reference 512
-frames a 2000-step run is roughly one to two hours for any family.
+CUDA / RTX 5070 Laptop, medium, rank 16, the reference 512 frames, averaged over steps 10-40. A
+2000-step run is 30-90 minutes depending on family; the two measured end to end came in at 34 min
+(`dora-rows`) and 64 min (`dora-cols`).
+
+Measure over enough steps to reach steady state. The first step carries graph build and, for
+`dora-rows`, the one-off `base_norm_sq` reduction over every targeted weight — 6.17 s against a
+1.25 s steady step, so a 2- or 3-step average is mostly setup and ranks the families wrongly.
 
 Two things used to make this table much worse, both fixed:
 
@@ -192,14 +197,13 @@ Two things used to make this table much worse, both fixed:
   and `ggml_scale` rejects one, so the column-norm helper's transposed gradient reached the
   scale on the low-rank delta. It now interposes a `cont`, whose backward re-materializes the
   gradient contiguously.
-- Six of the eight ran an unbatched monolithic backward asking for 24.6 GiB of allocator on an
-  8 GiB card, so the driver paged it to system RAM: `dora-cols` measured 92.76 s/step at 512
-  frames against 2.05 now. Gradient checkpointing had been gated to the two families
-  `dit_lin` can apply functionally; the rest now build their effective weight inside whichever
-  segment graph consumes it, so they are checkpointed too. See `--checkpoint-backward`.
+- Six of the eight ran a monolithic backward asking for 24.6 GiB of allocator on an 8 GiB card,
+  so the driver paged it to system RAM: `dora-cols` measured 92.76 s/step at 512 frames against
+  1.95 now, with the allocator down to 1126 MiB. Gradient checkpointing had been gated to the two
+  families `dit_lin` can apply functionally; the rest now build their effective weight inside
+  whichever segment graph consumes it, so they are checkpointed too. See `--checkpoint-backward`.
 
-`dora-rows` remains the default and the best-trodden path, and is now the slowest of the eight —
-the functional application costs more per step than materialized-plus-checkpointed at this size.
+`dora-rows` remains the default and the best-trodden path.
 
 Each sample is conditioned by its caption text. A dataset-level `prompt_config.json` can optionally
 compose that caption with general metadata tags or path-derived text.

--- a/src/train_ckpt.h
+++ b/src/train_ckpt.h
@@ -37,6 +37,7 @@
 #include "ggml-backend.h"
 
 #include <cstdio>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -66,6 +67,7 @@ struct TrainCkptBlock {
     ggml_tensor* grad_ctx = nullptr;    // this block's dL/dcontext contribution [dim, Ctx]
     ggml_tensor* grad_gcond = nullptr;  // this block's dL/dgcond contribution [6*dim]
     std::vector<size_t> param_idx;      // indices into lora.params / TrainDitCkpt::params
+    ggml_gallocr_t alloc = nullptr;     // borrowed from TrainDitCkpt::ballocs; see the note there
 };
 
 struct TrainDitCkpt {
@@ -102,7 +104,15 @@ struct TrainDitCkpt {
     ggml_tensor* velocity = nullptr;
     ggml_tensor* loss = nullptr;
     std::vector<size_t> tail_param_idx;
-    ggml_gallocr_t balloc = nullptr;    // shared by all block graphs (re-alloc'd per use)
+    // One allocator per DISTINCT block-graph shape, not one for all 24 blocks. With a uniform
+    // scope every block graph is identical, so a single allocator plans once and this is exactly
+    // the old behaviour. A scope that adapts only some blocks (--lora-include dit.0.) makes the
+    // graphs structurally different, and a shared gallocr then re-plans on every block boundary:
+    // ggml_gallocr_alloc_graph -> needs_realloc -> ggml_gallocr_reserve, which FREES and
+    // reallocates the buffer 24 times a step. That corrupted the step nondeterministically
+    // (~30% of runs died in ggml_cuda_set_device with "invalid device ordinal", or took an
+    // access violation). Grouping by shape means no allocator ever re-plans.
+    std::vector<ggml_gallocr_t> ballocs;
     std::vector<TrainCkptBlock> blocks;
     ggml_context* hctx = nullptr;       // H: head VJP, fwd+bwd
     ggml_gallocr_t halloc = nullptr;
@@ -119,7 +129,7 @@ struct TrainDitCkpt {
 inline void free_train_dit_ckpt(TrainDitCkpt& ck) {
     if (ck.falloc) ggml_gallocr_free(ck.falloc);
     if (ck.talloc) ggml_gallocr_free(ck.talloc);
-    if (ck.balloc) ggml_gallocr_free(ck.balloc);
+    for (ggml_gallocr_t a : ck.ballocs) if (a) ggml_gallocr_free(a);
     if (ck.halloc) ggml_gallocr_free(ck.halloc);
     for (TrainCkptBlock& b : ck.blocks) if (b.ctx) ggml_free(b.ctx);
     if (ck.fctx) ggml_free(ck.fctx);
@@ -372,10 +382,8 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
             return fail("failed to allocate tail training graph");
     }
 
-    // --- B_l: per-block VJP fwd+bwd, shared allocator (re-planned per use in the runner) ---
+    // --- B_l: per-block VJP fwd+bwd, one allocator per distinct graph shape ---
     {
-        out.balloc = ggml_gallocr_new(buft);
-        if (!out.balloc) return fail("failed to create block graph allocator");
         out.blocks.resize((size_t)dc.depth);
         for (int l = 0; l < dc.depth; ++l) {
             TrainCkptBlock& B = out.blocks[(size_t)l];
@@ -400,6 +408,25 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
             ggml_set_output(B.grad_ctx);
             ggml_set_output(B.grad_gcond);
             keep_param_grads(B.graph, B.param_idx);
+        }
+
+        // Group blocks by graph shape and give each group its own allocator, reserved once here.
+        // Two blocks share an allocator only when their graphs are structurally identical, so
+        // ggml_gallocr_alloc_graph in the runner never takes the realloc path. A uniform scope
+        // yields exactly one group, i.e. the previous single-allocator behaviour and memory use.
+        std::map<int, size_t> shape_to_alloc;   // graph node count -> index into ballocs
+        for (int l = 0; l < dc.depth; ++l) {
+            TrainCkptBlock& B = out.blocks[(size_t)l];
+            const int shape = ggml_graph_n_nodes(B.graph);
+            auto it = shape_to_alloc.find(shape);
+            if (it == shape_to_alloc.end()) {
+                ggml_gallocr_t a = ggml_gallocr_new(buft);
+                if (!a) return fail("failed to create block graph allocator");
+                out.ballocs.push_back(a);
+                if (!ggml_gallocr_reserve(a, B.graph)) return fail("failed to reserve block graph allocator");
+                it = shape_to_alloc.emplace(shape, out.ballocs.size() - 1).first;
+            }
+            B.alloc = out.ballocs[it->second];
         }
     }
 

--- a/src/train_ckpt.h
+++ b/src/train_ckpt.h
@@ -23,8 +23,9 @@
 // VRAM-resident; the price is one extra forward pass. All step inputs, adapter tensors and
 // boundary/grad carriers live in ONE persistent backend buffer that no gallocr ever touches
 // (this also retires the "re-upload base_norm_sq every step" workaround — constants uploaded at
-// build survive). Functional adapter families only (lora / dora-rows); others use the
-// monolithic path in train_dit.h.
+// build survive). All adapter families: lora / dora-rows reach dit_lin functionally, and the rest
+// materialize a W_eff inside whichever segment graph consumes it (see install_overrides), which is
+// the whole reason they fit — built once for the step they were ~24.6 GB of live f32 weights.
 #pragma once
 
 #include "dit.h"
@@ -88,7 +89,8 @@ struct TrainDitCkpt {
     ggml_tensor* Gctx_in = nullptr;     // [dim, ctx_len] summed dL/dcontext (uploaded before H)
     ggml_tensor* Ggcond_in = nullptr;   // [6*dim] summed dL/dgcond
     std::vector<TrainDitParamTensors> params;  // adapter tensors, indexed like lora.params
-    DitLora dl;
+    std::vector<TrainLoraGraphParam> gp;       // same order; feeds train_lora_effective_weight
+    DitLora dl;                                // functional families only; empty otherwise
 
     // --- graphs ---
     ggml_context* fctx = nullptr;       // F: forward + boundary copies
@@ -131,10 +133,6 @@ inline void free_train_dit_ckpt(TrainDitCkpt& ck) {
 inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const TrainLoraState& lora,
                                  int frames, int cond_dim, int ctx_len,
                                  TrainDitCkpt& out, std::string& err, bool inpaint = false) {
-    if (lora.adapter_type != "lora" && lora.adapter_type != "dora-rows") {
-        err = "checkpointed backward supports functional families only (lora, dora-rows)";
-        return false;
-    }
     if (frames <= 0 || cond_dim <= 0 || ctx_len <= 0) {
         err = "invalid DiT training graph dimensions";
         return false;
@@ -150,11 +148,19 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
     out.ctx_len = ctx_len;
     const int64_t S = (int64_t)dc.mem_tokens + frames;
     const bool dora = lora.adapter_type == "dora-rows";
+    // Families dit_lin can apply functionally; the rest materialize a W_eff per segment graph
+    // (see install_overrides). Both are checkpointed — the split is only about how the adapter
+    // reaches dit_lin, not about whether the step fits in VRAM.
+    const bool functional = lora.adapter_type == "lora" || lora.adapter_type == "dora-rows";
+    const bool xs = lora.adapter_type.size() >= 3 &&
+                    lora.adapter_type.compare(lora.adapter_type.size() - 3, 3, "-xs") == 0;
     auto fail = [&](const std::string& msg) { err = msg; free_train_dit_ckpt(out); return false; };
 
     // --- persistent tensors ---
     {
-        const size_t n_tensors = 24 + (size_t)(dc.depth + 1) + lora.params.size() * 4;
+        // Per target, the widest family is bora-xs: U, V, M_xs, magnitude_r, magnitude_c. Standard
+        // families use at most lora_A, lora_B, magnitude and base_norm_sq.
+        const size_t n_tensors = 24 + (size_t)(dc.depth + 1) + lora.params.size() * 6;
         ggml_init_params ip = { ggml_tensor_overhead() * (n_tensors + 64), nullptr, true };
         out.pctx = ggml_init(ip);
         if (!out.pctx) return fail("ggml_init failed for persistent training tensors");
@@ -186,26 +192,56 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
         for (const TrainLoraParam& hp : lora.params) {
             TrainDitParamTensors tp;
             tp.stem = hp.target.stem;
-            tp.lora_A = ggml_new_tensor_2d(out.pctx, GGML_TYPE_F32, hp.target.in, lora.rank);
-            tp.lora_B = ggml_new_tensor_2d(out.pctx, GGML_TYPE_F32, lora.rank, hp.target.out);
-            ggml_set_param(tp.lora_A);
-            ggml_set_param(tp.lora_B);
-            DitLoraParam dp;
-            dp.A = tp.lora_A;
-            dp.B = tp.lora_B;
-            dp.scale = lora.alpha / (float)lora.rank;
-            dp.in = hp.target.in;
-            if (dora) {
+            TrainLoraGraphParam gp;
+            if (xs) {
+                // Frozen SVD bases are inputs (uploaded, never trained); only M_xs is a parameter.
+                tp.U = ggml_new_tensor_2d(out.pctx, GGML_TYPE_F32, lora.rank, hp.target.out);
+                tp.V = ggml_new_tensor_2d(out.pctx, GGML_TYPE_F32, lora.rank, hp.target.in);
+                tp.M_xs = ggml_new_tensor_2d(out.pctx, GGML_TYPE_F32, lora.rank, lora.rank);
+                ggml_set_param(tp.M_xs);
+                gp.U = tp.U;
+                gp.V = tp.V;
+                gp.M_xs = tp.M_xs;
+            } else {
+                tp.lora_A = ggml_new_tensor_2d(out.pctx, GGML_TYPE_F32, hp.target.in, lora.rank);
+                tp.lora_B = ggml_new_tensor_2d(out.pctx, GGML_TYPE_F32, lora.rank, hp.target.out);
+                ggml_set_param(tp.lora_A);
+                ggml_set_param(tp.lora_B);
+                gp.lora_A = tp.lora_A;
+                gp.lora_B = tp.lora_B;
+            }
+            if (!hp.magnitude.empty()) {
                 tp.magnitude = ggml_new_tensor_1d(out.pctx, GGML_TYPE_F32, (int64_t)hp.magnitude.size());
                 ggml_set_param(tp.magnitude);
-                tp.base_norm_sq = ggml_new_tensor_1d(out.pctx, GGML_TYPE_F32, hp.target.out);
-                tp.base_norm_sq_host = train_row_norm_sq(dit.get(hp.target.weight_name), hp.target.in,
-                                                         hp.target.out, 1e-12f);
-                dp.dora = true;
-                dp.magnitude = tp.magnitude;
-                dp.base_norm_sq = tp.base_norm_sq;
+                gp.magnitude = tp.magnitude;
             }
-            out.dl[hp.target.weight_name] = dp;
+            if (!hp.magnitude_r.empty()) {
+                tp.magnitude_r = ggml_new_tensor_1d(out.pctx, GGML_TYPE_F32, (int64_t)hp.magnitude_r.size());
+                ggml_set_param(tp.magnitude_r);
+                gp.magnitude_r = tp.magnitude_r;
+            }
+            if (!hp.magnitude_c.empty()) {
+                tp.magnitude_c = ggml_new_tensor_1d(out.pctx, GGML_TYPE_F32, (int64_t)hp.magnitude_c.size());
+                ggml_set_param(tp.magnitude_c);
+                gp.magnitude_c = tp.magnitude_c;
+            }
+            if (functional) {
+                DitLoraParam dp;
+                dp.A = tp.lora_A;
+                dp.B = tp.lora_B;
+                dp.scale = lora.alpha / (float)lora.rank;
+                dp.in = hp.target.in;
+                if (dora) {
+                    tp.base_norm_sq = ggml_new_tensor_1d(out.pctx, GGML_TYPE_F32, hp.target.out);
+                    tp.base_norm_sq_host = train_row_norm_sq(dit.tensors.at(hp.target.weight_name),
+                                                             hp.target.in, hp.target.out, 1e-12f);
+                    dp.dora = true;
+                    dp.magnitude = tp.magnitude;
+                    dp.base_norm_sq = tp.base_norm_sq;
+                }
+                out.dl[hp.target.weight_name] = dp;
+            }
+            out.gp.push_back(gp);
             out.params.push_back(tp);
         }
 
@@ -235,6 +271,10 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
     }
 
     const ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(dit.backend);
+    // A materialized W_eff adds ~10 nodes per target on top of what the segment already needs, and
+    // bora-xs (xs delta + row norm + col norm) is the worst case, so the non-functional families
+    // get a larger node budget in every graph.
+    const size_t gsz = functional ? 1 : 2;
     auto graph_ctx = [&](size_t graph_size, bool grads) -> ggml_context* {
         ggml_init_params ip = { ggml_tensor_overhead() * graph_size * 3 +
                                 ggml_graph_overhead_custom(graph_size, grads), nullptr, true };
@@ -245,7 +285,8 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
     auto keep_param_grads = [&](ggml_cgraph* g, const std::vector<size_t>& idx) {
         for (size_t i : idx) {
             const TrainDitParamTensors& tp = out.params[i];
-            for (ggml_tensor* p : { tp.lora_A, tp.lora_B, tp.magnitude }) {
+            for (ggml_tensor* p : { tp.lora_A, tp.lora_B, tp.M_xs, tp.magnitude,
+                                    tp.magnitude_r, tp.magnitude_c }) {
                 if (!p) continue;
                 ggml_tensor* gr = ggml_graph_get_grad(g, p);
                 if (gr) ggml_set_output(gr);
@@ -253,21 +294,53 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
         }
     };
 
+    // Materialized families build their W_eff inside the graph that consumes it, rather than once
+    // for the whole step. That is what lets them be checkpointed at all: the monolithic graph kept
+    // all ~228 f32 effective weights alive from their forward use to their backward use (~24.6 GiB
+    // of gallocr buffer on an 8 GiB card, so the driver paged it to sysmem and every kernel
+    // crawled). Here F is forward-only, so gallocr reuses each W_eff's buffer as soon as its block
+    // has run, and T/B_l/H only ever build the targets their own segment owns.
+    // `idx == nullptr` means every target (F). Reads the base from `tensors`, never `get()`, since
+    // get() is transparently shadowed by whatever is currently installed.
+    auto install_overrides = [&](ggml_context* ctx, const std::vector<size_t>* idx) {
+        std::vector<std::string> names;
+        if (functional) return names;
+        const size_t n = idx ? idx->size() : lora.params.size();
+        names.reserve(n);
+        for (size_t k = 0; k < n; ++k) {
+            const size_t i = idx ? (*idx)[k] : k;
+            const std::string& wn = lora.params[i].target.weight_name;
+            dit.overrides[wn] = train_lora_effective_weight(ctx, dit.tensors.at(wn), out.gp[i],
+                                                            lora.adapter_type, lora.rank, lora.alpha);
+            names.push_back(wn);
+        }
+        return names;
+    };
+    auto erase_overrides = [&](const std::vector<std::string>& names) {
+        for (const std::string& n : names) dit.overrides.erase(n);
+    };
+    const DitLora* dl = functional ? &out.dl : nullptr;
+
     // --- F: forward + boundary copies ---
     {
-        out.fctx = graph_ctx(16384, false);
+        // A materialized W_eff costs ~10 extra nodes per target on top of the ~10.3k the forward
+        // already uses, so the non-functional families need the larger budget.
+        const size_t fsize = functional ? 16384 : 32768;
+        out.fctx = graph_ctx(fsize, false);
         if (!out.fctx) return fail("ggml_init failed for forward graph");
-        out.fgraph = ggml_new_graph_custom(out.fctx, 16384, false);
-        DitHeadOut h = dit_head(out.fctx, dit, out.x, out.tfeat, out.cross, out.global, dc, &out.dl, true);
+        out.fgraph = ggml_new_graph_custom(out.fctx, fsize, false);
+        const std::vector<std::string> ov = install_overrides(out.fctx, nullptr);
+        DitHeadOut h = dit_head(out.fctx, dit, out.x, out.tfeat, out.cross, out.global, dc, dl, true);
         ggml_build_forward_expand(out.fgraph, ggml_cpy(out.fctx, h.context, out.context_p));
         ggml_build_forward_expand(out.fgraph, ggml_cpy(out.fctx, h.gcond, out.gcond_p));
         ggml_tensor* xc = h.x0;
         ggml_build_forward_expand(out.fgraph, ggml_cpy(out.fctx, xc, out.xb[0]));
         for (int l = 0; l < dc.depth; ++l) {
             xc = dit_block(out.fctx, dit, "dit." + std::to_string(l) + ".", xc, h.context, h.gcond,
-                           out.pos, out.ones, dc, out.local, &out.dl, true);
+                           out.pos, out.ones, dc, out.local, dl, true);
             ggml_build_forward_expand(out.fgraph, ggml_cpy(out.fctx, xc, out.xb[(size_t)l + 1]));
         }
+        erase_overrides(ov);
         out.falloc = ggml_gallocr_new(buft);
         if (!out.falloc || !ggml_gallocr_alloc_graph(out.falloc, out.fgraph))
             return fail("failed to allocate checkpointed forward graph");
@@ -275,10 +348,11 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
 
     // --- T: tail + real loss, fwd+bwd; emits dL/dx_depth ---
     {
-        out.tctx = graph_ctx(2048, true);
+        out.tctx = graph_ctx(2048 * gsz, true);
         if (!out.tctx) return fail("ggml_init failed for tail graph");
-        out.tgraph = ggml_new_graph_custom(out.tctx, 2048, true);
-        ggml_tensor* vel = ggml_cont(out.tctx, dit_tail(out.tctx, dit, out.xb[(size_t)dc.depth], dc, &out.dl, true));
+        out.tgraph = ggml_new_graph_custom(out.tctx, 2048 * gsz, true);
+        const std::vector<std::string> ov = install_overrides(out.tctx, &out.tail_param_idx);
+        ggml_tensor* vel = ggml_cont(out.tctx, dit_tail(out.tctx, dit, out.xb[(size_t)dc.depth], dc, dl, true));
         out.velocity = vel;
         ggml_set_output(vel);
         ggml_tensor* sq = ggml_sqr(out.tctx, ggml_sub(out.tctx, vel, out.target));
@@ -288,6 +362,7 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
         ggml_set_output(out.loss);
         ggml_build_forward_expand(out.tgraph, out.loss);
         ggml_build_backward_expand(out.tctx, out.tgraph, nullptr);
+        erase_overrides(ov);
         ggml_tensor* gx = ggml_graph_get_grad(out.tgraph, out.xb[(size_t)dc.depth]);
         if (!gx) return fail("tail graph produced no dL/dx gradient");
         ggml_build_forward_expand(out.tgraph, ggml_cpy(out.tctx, gx, out.g_in(dc.depth - 1)));
@@ -305,15 +380,17 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
         for (int l = 0; l < dc.depth; ++l) {
             TrainCkptBlock& B = out.blocks[(size_t)l];
             B.param_idx = block_param_idx[(size_t)l];
-            B.ctx = graph_ctx(6144, true);
+            B.ctx = graph_ctx(6144 * gsz, true);
             if (!B.ctx) return fail("ggml_init failed for block graph");
-            B.graph = ggml_new_graph_custom(B.ctx, 6144, true);
+            B.graph = ggml_new_graph_custom(B.ctx, 6144 * gsz, true);
+            const std::vector<std::string> ov = install_overrides(B.ctx, &B.param_idx);
             ggml_tensor* xo = dit_block(B.ctx, dit, "dit." + std::to_string(l) + ".", out.xb[(size_t)l],
-                                        out.context_p, out.gcond_p, out.pos, out.ones, dc, out.local, &out.dl, true);
+                                        out.context_p, out.gcond_p, out.pos, out.ones, dc, out.local, dl, true);
             ggml_tensor* vjp = ggml_sum(B.ctx, ggml_mul(B.ctx, xo, out.g_in(l)));
             ggml_set_loss(vjp);
             ggml_build_forward_expand(B.graph, vjp);
             ggml_build_backward_expand(B.ctx, B.graph, nullptr);
+            erase_overrides(ov);
             ggml_tensor* gx = ggml_graph_get_grad(B.graph, out.xb[(size_t)l]);
             if (!gx) return fail("block graph produced no dL/dx gradient");
             ggml_build_forward_expand(B.graph, ggml_cpy(B.ctx, gx, out.g_out(l)));
@@ -334,10 +411,11 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
     // ggml_build_backward_expand would assert "no trainable parameters found". That is what a
     // --lora-scope of core does, since core keeps only the 24 blocks' own projections.
     if (!out.head_param_idx.empty()) {
-        out.hctx = graph_ctx(4096, true);
+        out.hctx = graph_ctx(4096 * gsz, true);
         if (!out.hctx) return fail("ggml_init failed for head graph");
-        out.hgraph = ggml_new_graph_custom(out.hctx, 4096, true);
-        DitHeadOut h = dit_head(out.hctx, dit, out.x, out.tfeat, out.cross, out.global, dc, &out.dl, true);
+        out.hgraph = ggml_new_graph_custom(out.hctx, 4096 * gsz, true);
+        const std::vector<std::string> ov = install_overrides(out.hctx, &out.head_param_idx);
+        DitHeadOut h = dit_head(out.hctx, dit, out.x, out.tfeat, out.cross, out.global, dc, dl, true);
         ggml_tensor* vjp = ggml_add(out.hctx,
             ggml_add(out.hctx,
                 ggml_sum(out.hctx, ggml_mul(out.hctx, h.x0, out.g_out(0))),
@@ -346,6 +424,7 @@ inline bool build_train_dit_ckpt(GgufModel& dit, const DitConfig& dc, const Trai
         ggml_set_loss(vjp);
         ggml_build_forward_expand(out.hgraph, vjp);
         ggml_build_backward_expand(out.hctx, out.hgraph, nullptr);
+        erase_overrides(ov);
         keep_param_grads(out.hgraph, out.head_param_idx);
         out.halloc = ggml_gallocr_new(buft);
         if (!out.halloc || !ggml_gallocr_alloc_graph(out.halloc, out.hgraph))

--- a/src/train_config.h
+++ b/src/train_config.h
@@ -72,9 +72,8 @@ struct TrainConfig {
     bool random_crop = true;
     // Gradient-checkpointed backward (train_ckpt.h): run the DiT backward block-by-block so peak
     // activation memory is one block's working set instead of the whole graph (the monolithic
-    // fwd+bwd graph needs ~9.6 GB at 512 frames and pages out of VRAM on 8 GB cards). Only the
-    // functional adapter families (lora, dora-rows) support it; others fall back to the
-    // monolithic graph automatically.
+    // fwd+bwd graph needs ~9.6 GB at 512 frames -- ~24.6 GB for the materialized families -- and
+    // pages out of VRAM on 8 GB cards). All adapter families support it.
     bool ckpt_backward = true;
     // Pre-encoded latents (train_latents.h): encode each training file ONCE, full-length, at
     // startup and random-crop in LATENT space per step — the reference training method (required

--- a/src/train_loop.h
+++ b/src/train_loop.h
@@ -389,14 +389,17 @@ inline bool run_train_dit_accumulate_ckpt(ggml_backend_t backend, TrainDitCkpt& 
     static bool balloc_logged = false;
     for (int l = dc.depth - 1; l >= 0; --l) {
         TrainCkptBlock& B = ck.blocks[(size_t)l];
-        if (!ggml_gallocr_alloc_graph(ck.balloc, B.graph)) {
+        if (!ggml_gallocr_alloc_graph(B.alloc, B.graph)) {
             err = "failed to allocate block training graph";
             return false;
         }
         if (!balloc_logged) {
             balloc_logged = true;
-            std::fprintf(stderr, "[train] block fwd+bwd gallocr buffer: %.1f MiB (shared by %d block graphs)\n",
-                         ggml_gallocr_get_buffer_size(ck.balloc, 0) / (1024.0 * 1024.0), dc.depth);
+            double total = 0.0;
+            for (ggml_gallocr_t a : ck.ballocs) total += ggml_gallocr_get_buffer_size(a, 0) / (1024.0 * 1024.0);
+            std::fprintf(stderr,
+                         "[train] block fwd+bwd gallocr buffer: %.1f MiB across %zu graph shape(s) for %d blocks\n",
+                         total, ck.ballocs.size(), dc.depth);
         }
         ggml_graph_reset(B.graph);
         ggml_backend_graph_compute(backend, B.graph);

--- a/src/train_loop.h
+++ b/src/train_loop.h
@@ -278,10 +278,25 @@ inline bool train_accum_read_subset(ggml_cgraph* graph, const TrainDitCkpt& ck,
             if (!found) { err = "missing gradient for " + tp.stem + " lora_B"; return false; }
             train_accum_add(accum.B[i], grad);
         }
+        if (tp.M_xs) {
+            if (!train_read_grad(graph, tp.M_xs, grad, found, err)) return false;
+            if (!found) { err = "missing gradient for " + tp.stem + " M_xs"; return false; }
+            train_accum_add(accum.mxs[i], grad);
+        }
         if (tp.magnitude) {
             if (!train_read_grad(graph, tp.magnitude, grad, found, err)) return false;
             if (!found) { err = "missing gradient for " + tp.stem + " magnitude"; return false; }
             train_accum_add(accum.mag[i], grad);
+        }
+        if (tp.magnitude_r) {
+            if (!train_read_grad(graph, tp.magnitude_r, grad, found, err)) return false;
+            if (!found) { err = "missing gradient for " + tp.stem + " magnitude_r"; return false; }
+            train_accum_add(accum.mag_r[i], grad);
+        }
+        if (tp.magnitude_c) {
+            if (!train_read_grad(graph, tp.magnitude_c, grad, found, err)) return false;
+            if (!found) { err = "missing gradient for " + tp.stem + " magnitude_c"; return false; }
+            train_accum_add(accum.mag_c[i], grad);
         }
     }
     return true;
@@ -318,8 +333,15 @@ inline bool run_train_dit_accumulate_ckpt(ggml_backend_t backend, TrainDitCkpt& 
         const TrainDitParamTensors& tp = ck.params[i];
         if (tp.lora_A) ggml_backend_tensor_set(tp.lora_A, hp.lora_A.data(), 0, hp.lora_A.size() * sizeof(float));
         if (tp.lora_B) ggml_backend_tensor_set(tp.lora_B, hp.lora_B.data(), 0, hp.lora_B.size() * sizeof(float));
+        if (tp.U) ggml_backend_tensor_set(tp.U, hp.U.data(), 0, hp.U.size() * sizeof(float));
+        if (tp.V) ggml_backend_tensor_set(tp.V, hp.V.data(), 0, hp.V.size() * sizeof(float));
+        if (tp.M_xs) ggml_backend_tensor_set(tp.M_xs, hp.M_xs.data(), 0, hp.M_xs.size() * sizeof(float));
         if (tp.magnitude && !hp.magnitude.empty())
             ggml_backend_tensor_set(tp.magnitude, hp.magnitude.data(), 0, hp.magnitude.size() * sizeof(float));
+        if (tp.magnitude_r && !hp.magnitude_r.empty())
+            ggml_backend_tensor_set(tp.magnitude_r, hp.magnitude_r.data(), 0, hp.magnitude_r.size() * sizeof(float));
+        if (tp.magnitude_c && !hp.magnitude_c.empty())
+            ggml_backend_tensor_set(tp.magnitude_c, hp.magnitude_c.data(), 0, hp.magnitude_c.size() * sizeof(float));
     }
     // step inputs
     std::vector<float> tf;

--- a/src/train_lora.h
+++ b/src/train_lora.h
@@ -274,6 +274,14 @@ inline bool init_train_lora_state(const GgufModel& dit, const std::vector<TrainL
 
 inline ggml_tensor* train_lora_apply_col_norm(ggml_context* ctx, ggml_tensor* v,
                                               ggml_tensor* magnitude, int64_t in, int64_t out) {
+    // The leading cont is for the BACKWARD pass, not the forward one, where it is a plain copy.
+    // ggml differentiates transpose as a bare ggml_transpose(grad) (a non-contiguous view) while
+    // ggml_scale asserts ggml_is_padded_1d, so a transposed gradient reaching a scale node aborts
+    // the graph build. dora-cols hits exactly that: v = w + scale(delta), and add's backward hands
+    // its gradient straight to the scale. Interposing a cont makes ggml's CONT backward
+    // re-materialize the gradient contiguously before it gets there. bora survives without this
+    // only because its rms_norm/mul layer already allocates a fresh contiguous gradient.
+    v = ggml_cont(ctx, v);
     ggml_tensor* vt = ggml_cont(ctx, ggml_transpose(ctx, v)); // [out, in]
     ggml_tensor* mag = ggml_reshape_2d(ctx, magnitude, 1, in); // [1, in]
     ggml_tensor* vn = ggml_scale(ctx, ggml_rms_norm(ctx, vt, 1e-12f), 1.0f / sqrtf((float)out));

--- a/tools/sa3-train.cpp
+++ b/tools/sa3-train.cpp
@@ -389,9 +389,10 @@ int main(int argc, char** argv) {
         sa3::TrainDitGraph graph;
         sa3::TrainDitCkpt ck;
         // Checkpointed (per-block) backward: peak activation memory is one block's working set,
-        // so the step stays VRAM-resident. Functional families only; others use the monolithic graph.
-        const bool use_ckpt = cfg.ckpt_backward &&
-                              (cfg.adapter_type == "lora" || cfg.adapter_type == "dora-rows");
+        // so the step stays VRAM-resident. Every adapter family supports it -- the families
+        // dit_lin cannot apply functionally materialize their W_eff inside each segment's own
+        // graph instead of once for the whole step (see install_overrides in train_ckpt.h).
+        const bool use_ckpt = cfg.ckpt_backward;
         int graph_frames = 0, graph_cond_dim = 0, graph_ctx_len = 0;
         sa3::TrainAdamWParams opt;
         opt.learning_rate = cfg.learning_rate;


### PR DESCRIPTION
Two of the eight adapter families could not be trained at all, and six of the eight trained
tens of times slower than they should have. Both are fixed here, and neither cause was what it
looked like.

## dora-cols could not build a backward graph

`dora-cols` and `dora-cols-xs` aborted in `ggml_build_backward_expand` on
`GGML_ASSERT(ggml_is_padded_1d(a))`.

The obvious reading is that column normalization is at fault — both failing families normalize
over columns, and no other family does. That reading is wrong, and `bora` proves it: `bora` calls
the very same `train_lora_apply_col_norm` and never crashed.

The assert lives in `ggml_scale`, which requires a padded-1d input. ggml differentiates transpose
as a bare `ggml_transpose(grad)` — a non-contiguous view, with no `cont` (`ggml.c:6756`), unlike
`GGML_OP_CONT` which explicitly re-materializes (`ggml.c:6701`). The column-norm helper transposes
`v`, so the gradient arriving back at `v` is that view. For `dora-cols`, `v = w + scale(delta)`,
and add's backward forwards its gradient unchanged straight into the `ggml_scale` node, whose own
backward calls `ggml_scale` on the view.

So the real trigger is a transposed gradient reaching a scale node. `bora` survives only because
its `rms_norm`/`mul` layer sits between the transpose and the scale and allocates a fresh
contiguous gradient on the way past; `dora-rows` never transposes at all.

The fix interposes a `cont` on the helper's input. In the forward pass it is a copy; the point is
the backward, where CONT's backward makes the gradient contiguous before it can reach the scale.
`bora` is bit-identical before and after.

## The other six were paying for 24.6 GiB of VRAM they did not have

At the reference 512 frames, `dora-cols` measured **92.76 s/step** against `dora-rows`' steady
1.25 s. That looks like an arithmetic problem. It is not:

| | graph | allocator |
|---|---|---|
| `dora-rows` | checkpointed, 24 block graphs | **407 MiB** |
| `dora-cols` | one monolithic graph | **24,629 MiB** |

24.6 GiB requested on an 8,150 MiB card, so the driver pages it to system RAM and every kernel
crawls. These families were never slow — they were never checkpointed.

Checkpointing was gated to `lora`/`dora-rows` for one reason: it needs the adapter to reach
`dit_lin` inside each per-block graph, and the other families install a materialized `W_eff` on
`dit.overrides` built once for the whole step. That is a plumbing coupling, not a mathematical
one.

Now each segment builds the `W_eff` it consumes. `F` is forward-only, so gallocr reuses each
one's buffer as soon as its block has run; `T`, `B_l` and `H` only ever build the targets their
own segment owns. Peak stays one segment's working set, which is the entire point of the
checkpointed decomposition.

## Parity

The arithmetic is untouched and the numbers confirm it. Every family reproduces its monolithic
loss and `grad_norm` **to the last digit**, at 128 and 512 frames. `dora-cols` at 512 frames:
`0.653433 / 0.855772` and gnorm `0.1077 / 0.1237` on both paths, with the allocator down from
24,629 to 1,126 MiB and the step from 92.76 s to 1.95 s.

## Results

Steady-state s/step, medium, rank 16, 512 frames, CUDA / RTX 5070 Laptop, averaged over steps
10–40:

| family | s/step | first step |
|---|---:|---:|
| `lora` | 0.80 | 1.02 |
| `lora-xs` | 1.05 | 1.33 |
| `dora-rows` | 1.25 | 6.17 |
| `dora-rows-xs` | 1.57 | 2.00 |
| `dora-cols-xs` | 1.84 | 2.31 |
| `dora-cols` | 1.95 | 2.35 |
| `bora-xs` | 2.33 | 2.67 |
| `bora` | 2.47 | 2.88 |

The ordering matches the arithmetic: plain, then the `-xs` variants, then row norm, then column
norm, then `bora` doing both. End to end, matched 2000-step runs on the same dataset came in at
34 min (`dora-rows`) and 64 min (`dora-cols`) — `dora-cols` was previously a ~51 hour proposition.

Measure over enough steps to reach steady state: `dora-rows` pays a one-off 6.17 s `base_norm_sq`
reduction on step 1 against a 1.25 s steady step, so short averages over-report it ~3x and rank
the families wrongly. An earlier revision of this PR did exactly that and claimed the functional
path was the slowest of the eight; it is third fastest, and that claim is withdrawn.

## Verification

- 17/17 ctest pass.
- All 8 families train at 128 and 512 frames, exact parity against the monolithic reference.
- Matched 2000-step `dora-rows` vs `dora-cols` runs on a real dataset both converge
  (loss 0.6727 → 0.6098 and 0.6742 → 0.6259 over first/last 100 steps) and produce audio.
- Not yet run on Metal — the checkpointed path is the one that changed, so it is worth
  confirming there.
