### PR TITLE
models: publish the text encoder in F16 and Q8_0

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -61,7 +61,7 @@ stable-audio-3-small-sfx-same-s-v1.0-{F32,F16}.gguf
 stable-audio-3-small-sfx-conditioner-v1.0-F32.gguf
 
 # shared text encoder + tokenizer  (repo: t5gemma-b-b-ul2-GGUF)
-t5gemma-b-b-ul2-encoder-0.3B-v1.0-F32.gguf
+t5gemma-b-b-ul2-encoder-0.3B-v1.0-{F16,F32,Q8_0}.gguf
 t5gemma-b-b-ul2-v1.0-vocab.gguf
 
 # adapters (live with the repo they target, or a loras repo)

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -113,7 +113,32 @@ also fetches the matching dedicated base-DiT repo used by `sa3-train`.
 
 published per variant, for **both** the DiT and the SAME: `F32`, `F16`, `Q8_0`, `Q5_K_M`, `Q4_K_M`.
 `--encoding` selects the pair (`sa3-generate` resolves DiT and SAME with the same suffix). the
-conditioner, text encoder and tokenizer stay `F32` — small and quality-critical, nothing to gain.
+conditioner and tokenizer stay `F32` — those two really are small (793 KiB and 14 MiB).
+
+**the text encoder is published `F16` (default), `F32` and `Q8_0`**, selected by `--t5-encoding`
+independently of `--encoding` — the combination worth having on a small device is a quantized DiT
+with an F16 encoder. an earlier revision of this section lumped the encoder in with the conditioner
+and tokenizer as "small and quality-critical, nothing to gain". it is not small: at F32 it is
+**1074 MiB**, the largest single file in the set and bigger than a small-music DiT.
+
+measured on small-music/Metal against an F32 control, swapping *only* the encoder:
+
+| encoder | size | conditioning cosine | generated-audio cosine | small-music train peak |
+|---|---:|---:|---:|---:|
+| F32 | 1074 MiB | — | — | 2.28 GiB |
+| **F16** | **537 MiB** | 1.000000000 | 0.999971 | **1.78 GiB** |
+| Q8_0 | 285 MiB | 0.999789 | 0.991496 | 1.52 GiB |
+| ~~Q4_K_M~~ | 206 MiB | 0.977908 | **0.797692** | 1.46 GiB |
+
+`Q4_K_M` is **not published** for the encoder, on evidence rather than caution: it is **11.8% slower
+than F32** here — the T5 forward is too small to amortize dequant, the opposite of the DiT result
+above — while dropping generated-audio cosine to 0.798, which is a different piece of music rather
+than a degraded one. `Q8_0` dominates it on every axis.
+
+> ⚠️ **do not validate an encoder with a loss curve.** `Q4_K_M` moved mean training loss by **0.02%**
+> over 100 matched steps while producing that 0.798. diffusion loss averages velocity error over
+> every latent position, so a shifted prompt embedding still predicts velocity well — just for a
+> subtly different prompt. use conditioning cosine (`SA3_DUMP_COND`) and generated audio.
 
 an earlier revision of this section said to keep the SAME at F16/F32 rather than quantize it. that
 was a precaution written before the tooling existed, and measurement superseded it: `sa3-quant-check`

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -21,6 +21,7 @@ full contract is in [`src/libsa3.h`](../src/libsa3.h). The shape:
 sa3_config_ex cfg = {0};
 cfg.config.models_dir = absolute_models_dir;
 cfg.config.variant = "small-music";
+cfg.text_encoder_encoding = "f16";                        // NULL = auto (prefers F16); see DISTRIBUTION.md
 cfg.config.encoding = "f16";
 cfg.cpu_threads = 8;                                      // CPU backend only; 0 = SA3_THREADS/default
 sa3_context* ctx = sa3_init_ex(&cfg, err, sizeof err);     // load the models (blocks ~seconds)
@@ -79,6 +80,7 @@ cfg.dataset_dir = "/path/to/dataset";      // laid out as docs/TRAINING.md descr
 cfg.output_dir  = "/path/to/run";
 cfg.variant     = "small-music";
 cfg.encoding    = "q4_k_m";                 // quantized bases train on every backend
+cfg.text_encoder_encoding = "f16";          // NULL = auto; F16 halves the encoder for free
 cfg.steps       = 2000;
 cfg.frames      = 128;                      // ~11.9 s crops; 512 is the reference regime
 cfg.seed        = 42;

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -12,6 +12,9 @@ for progress and, on completion, the base64 audio. That makes it a drop-in for a
 ```bash
 ./build/bin/Release/sa3-server.exe --model medium --encoding f16 --port 8006
 # args: --host (default 127.0.0.1) --port (8006) --model <variant> --encoding f16|f32
+#       --t5-encoding f16|f32|q8_0 — text-encoder precision, resolved apart from --encoding;
+#         default auto (prefers F16). a quantized DiT with an F16 encoder is the combination
+#         worth having on a small box. see docs/DISTRIBUTION.md
 #       --models-dir DIR (or SA3_MODELS_DIR) --adapters-dir DIR (or SA3_ADAPTERS_DIR)
 #       --threads N (or SA3_THREADS, CPU backend only)
 #       --prompts-dir DIR (or SA3_PROMPTS_DIR)
@@ -34,7 +37,7 @@ it binds to `127.0.0.1` by default (local only). The model loads lazily on the f
 |---|---|---|
 | `GET`  | `/loras`    | `{success, loras:[{index,name,path}], adapters_dir, model_loaded}` |
 | `GET`  | `/prompts`  | prompt dice pools, optionally blended with `?lora=name` or `?lora=a,b` |
-| `GET`  | `/health`   | `{status, model, encoding, loaded}` (lock-free — never blocks behind a gen) |
+| `GET`  | `/health`   | `{status, model, encoding, t5_encoding, loaded}` (lock-free — never blocks behind a gen) |
 | `POST` | `/generate` | JSON request (below) → **`{success, session_id, seed}`** immediately; generation runs in the background |
 | `POST` | `/generate/loop` | same request plus `bpm`/prompt BPM and `bars` for exact-length loop generation |
 | `GET`  | `/poll_status/<session_id>` | `{success, generation_in_progress, progress, step, total_steps, status, queue_status, ...}`; on `status:"completed"` also `audio_data` (base64 wav) + `meta:{seed}` |

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -26,6 +26,7 @@ sa3-train --dataset /path/to/dataset --steps 2000 \
 | `--rank N` | `16` | adapter capacity. `--alpha` follows it automatically, so raising rank does **not** silently weaken the adapter. |
 | `--duration SEC` | — | seconds of audio per training crop. Without it you get `--frames 512`, which is **47.6 s**. |
 | `--lora-scope full\|core` | `full` | `core` adapts only the 24 blocks' own projections (168 weights instead of 228): ~10% faster steps and ~11% smaller adapters, and in a matched 2000-step run the loss curve was within 0.0013 of `full` throughout. |
+| `--t5-encoding ENC` | auto | text-encoder precision, resolved apart from `--encoding`. Auto prefers `F16`, which is equivalent to `F32` at half the size (1074 → 537 MiB) and takes small-music's training peak from 2.28 to 1.78 GiB. `q8_0` saves another 0.26 GiB for a small, audible-on-paper cost. |
 | `--encoding ENC` | `f16` | base precision. Quantized bases (`q4_k_m`, `q8_0`, …) train on every backend and are both smaller and faster — on an M4 a `q4_k_m` medium base ran 2.77 s/step against 3.28 s/step for f16, on 962 MiB instead of 2773 MiB. |
 
 Two things that are easy to miss:

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -26,7 +26,7 @@ sa3-train --dataset /path/to/dataset --steps 2000 \
 | `--rank N` | `16` | adapter capacity. `--alpha` follows it automatically, so raising rank does **not** silently weaken the adapter. |
 | `--duration SEC` | — | seconds of audio per training crop. Without it you get `--frames 512`, which is **47.6 s**. |
 | `--lora-scope full\|core` | `full` | `core` adapts only the 24 blocks' own projections (168 weights instead of 228): ~10% faster steps and ~11% smaller adapters, and in a matched 2000-step run the loss curve was within 0.0013 of `full` throughout. |
-| `--t5-encoding ENC` | auto | text-encoder precision, resolved apart from `--encoding`. Auto prefers `F16`, which is equivalent to `F32` at half the size (1074 → 537 MiB) and takes small-music's training peak from 2.28 to 1.78 GiB. `q8_0` saves another 0.26 GiB for a small, audible-on-paper cost. |
+| `--t5-encoding ENC` | auto | text-encoder precision, resolved apart from `--encoding`. Auto prefers `F16`, which is equivalent to `F32` at half the size (1074 → 537 MiB) and takes small-music's training peak from 2.28 to 1.78 GiB. `q8_0` saves another 0.26 GiB for a small, audible-on-paper cost. **Pick it for memory, never for speed:** encoding the caption is `t5_cond` in `SA3_TRAIN_PROFILE=1`, and on CUDA/medium that is **9 ms of a 1070 ms step — 0.84%** — so `q8_0` moves the step by −1 ms, within noise of `f16` (see below). |
 | `--encoding ENC` | `f16` | base precision. Quantized bases (`q4_k_m`, `q8_0`, …) train on every backend and are both smaller and faster — on an M4 a `q4_k_m` medium base ran 2.77 s/step against 3.28 s/step for f16, on 962 MiB instead of 2773 MiB. |
 
 Two things that are easy to miss:
@@ -344,6 +344,29 @@ build-cuda/bin/sa3-generate \
   --seed 42 \
   --out train-runs/my-training-run/evaluation.wav
 ```
+
+## text-encoder precision does not move training time
+
+Measured on CUDA / medium-base F16 / 512 frames, `SA3_TRAIN_PROFILE=1`, medians over steps 11-50,
+run **ABBA** (f16, q8_0, q8_0, f16) rather than A-then-B:
+
+| block | encoder | `t5_cond` | `dit` | total |
+|---|---|---:|---:|---:|
+| 1 (early) | F16 | 9 ms | 979 ms | 1062 ms |
+| 2 | Q8_0 | 8 ms | 977 ms | 1064 ms |
+| 3 | Q8_0 | 8 ms | 988 ms | 1075 ms |
+| 4 (late) | F16 | 9 ms | 992 ms | 1080 ms |
+| **pooled** | **F16** | **9 ms** | 984 ms | **1069.5 ms** |
+| **pooled** | **Q8_0** | **8 ms** | 986 ms | **1070.0 ms** |
+
+Pooled, `q8_0` is **+0.05%** on total step time and **1 ms faster** on the encoder itself: the two
+are the same speed, and the encoder is under 1% of a step either way.
+
+> ⚠️ **the ordering is the whole point.** Total step time drifts upward across the session
+> (1062 → 1064 → 1075 → 1080 ms) as the GPU heats. Run A-then-B and that drift lands entirely on
+> the second arm, "showing" `q8_0` about 1.3% slower — a wrong sign produced by a real effect that
+> has nothing to do with the encoder. ABBA gives each arm one early and one late block so the drift
+> cancels. The same trap applies to any A/B on this machine, not just this one.
 
 ## Troubleshooting
 

--- a/docs/model-cards/t5gemma-b-b-ul2-GGUF.md
+++ b/docs/model-cards/t5gemma-b-b-ul2-GGUF.md
@@ -23,10 +23,36 @@ repo. Validated against the PyTorch reference at cosine similarity ~1.0.
 
 ## Files
 
-| component | file | notes |
-|---|---|---|
-| text encoder | `t5gemma-b-b-ul2-encoder-0.3B-v1.0-F32.gguf` | encoder weights only (no conditioner) |
-| tokenizer | `t5gemma-b-b-ul2-v1.0-vocab.gguf` | Gemma byte-fallback BPE |
+| component | file | size | notes |
+|---|---|---:|---|
+| text encoder | `t5gemma-b-b-ul2-encoder-0.3B-v1.0-F16.gguf` | 537 MiB | **default** — equivalent to F32 |
+| text encoder | `t5gemma-b-b-ul2-encoder-0.3B-v1.0-F32.gguf` | 1074 MiB | reference precision |
+| text encoder | `t5gemma-b-b-ul2-encoder-0.3B-v1.0-Q8_0.gguf` | 285 MiB | smallest; a small, real tradeoff |
+| tokenizer | `t5gemma-b-b-ul2-v1.0-vocab.gguf` | 14 MiB | Gemma byte-fallback BPE |
+
+The encoder carries **no conditioner** — that ships per-variant in each model repo.
+
+### picking an encoder precision
+
+Measured against an F32 control, swapping *only* the encoder:
+
+| encoder | conditioning cosine | generated-audio cosine |
+|---|---:|---:|
+| **F16** | 0.999995 | 0.999848 |
+| Q8_0 | 0.999547 | 0.999108 |
+
+`F16` is what `sa3.cpp` downloads and resolves by default, and it is a size win rather than a
+fidelity substitution. `Q8_0` is offered for tight-memory installs; it is a small but real
+tradeoff, so it is never auto-selected — ask for it by name.
+
+`Q4_K_M` is **not published** for this encoder, on evidence rather than caution: it is *slower*
+than F32 here (the T5 forward is too small to amortize dequant, unlike the DiT) while dropping
+generated-audio cosine to ~0.80, which is a different piece of music rather than a degraded one.
+`Q8_0` dominates it on every axis.
+
+Select a precision with `--t5-encoding f16|f32|q8_0`, independently of the `--encoding` that picks
+the DiT/SAME tier — the combination worth having on a small device is a quantized DiT with an F16
+encoder. This works the same way at inference (`sa3-generate`) and at training (`sa3-train`).
 
 Pair these with any SA3 variant repo's DiT + SAME + conditioner:
 [medium](https://huggingface.co/thepatch/stable-audio-3-medium-GGUF) ·

--- a/models.cmd
+++ b/models.cmd
@@ -1,11 +1,13 @@
 @echo off
 setlocal enabledelayedexpansion
 rem Download the sa3.cpp GGUF model set from HuggingFace (public repos) with curl.exe - no Python.
-rem Usage: models.cmd [--variant medium^|small-music^|small-sfx] [--encoding f16^|f32^|q4_k_m^|q5_k_m^|q8_0] [--training-base] [--namespace <hf-user>] [--out DIR] [--dry-run]
+rem Usage: models.cmd [--variant medium^|small-music^|small-sfx] [--encoding f16^|f32^|q4_k_m^|q5_k_m^|q8_0] [--t5-encoding f16^|f32^|q8_0] [--training-base] [--namespace <hf-user>] [--out DIR] [--dry-run]
 rem   default: medium f16 into .\models
 
 set "VARIANT=medium"
 set "ENCODING=f16"
+rem The text encoder resolves apart from the DiT/SAME: F16 is equivalent to F32 at half the size.
+set "T5_ENCODING=f16"
 set "NAMESPACE=thepatch"
 set "OUT=models"
 set "TRAINING_BASE=0"
@@ -15,6 +17,7 @@ set "DRY_RUN=0"
 if "%~1"=="" goto parsed
 if /I "%~1"=="--variant"   ( set "VARIANT=%~2" & shift & shift & goto parse )
 if /I "%~1"=="--encoding"  ( set "ENCODING=%~2" & shift & shift & goto parse )
+if /I "%~1"=="--t5-encoding" ( set "T5_ENCODING=%~2" & shift & shift & goto parse )
 if /I "%~1"=="--namespace" ( set "NAMESPACE=%~2" & shift & shift & goto parse )
 if /I "%~1"=="--out"       ( set "OUT=%~2" & shift & shift & goto parse )
 if /I "%~1"=="--training-base" ( set "TRAINING_BASE=1" & shift & goto parse )
@@ -41,6 +44,14 @@ if /I "%ENCODING%"=="q8_0"   ( set "ENC=Q8_0"    & set "BASE_ENC=F16" & goto enc
 echo unknown encoding: %ENCODING% ^(f16^|f32^|q4_k_m^|q5_k_m^|q8_0^) & exit /b 1
 :encoding_ok
 if not defined BASE_ENC set "BASE_ENC=%ENC%"
+set "T5_ENC="
+if /I "%T5_ENCODING%"=="f16"  set "T5_ENC=F16"
+if /I "%T5_ENCODING%"=="f32"  set "T5_ENC=F32"
+if /I "%T5_ENCODING%"=="q8_0" set "T5_ENC=Q8_0"
+if not defined T5_ENC (
+    echo unknown --t5-encoding "%T5_ENCODING%" ^(expected f16^|f32^|q8_0^) 1>&2
+    exit /b 2
+)
 set "VAR_REPO=%NAMESPACE%/stable-audio-3-%VARIANT%-GGUF"
 set "BASE_REPO=%NAMESPACE%/stable-audio-3-%VARIANT%-base-GGUF"
 set "SHARED=%NAMESPACE%/t5gemma-b-b-ul2-GGUF"
@@ -57,7 +68,7 @@ call :dl "%VAR_REPO%" "%BASE%-%SAME%-v1.0-%ENC%.gguf"
 if errorlevel 1 exit /b 1
 call :dl "%VAR_REPO%" "%BASE%-conditioner-v1.0-F32.gguf"
 if errorlevel 1 exit /b 1
-call :dl "%SHARED%"   "t5gemma-b-b-ul2-encoder-0.3B-v1.0-F32.gguf"
+call :dl "%SHARED%"   "t5gemma-b-b-ul2-encoder-0.3B-v1.0-%T5_ENC%.gguf"
 if errorlevel 1 exit /b 1
 call :dl "%SHARED%"   "t5gemma-b-b-ul2-v1.0-vocab.gguf"
 if errorlevel 1 exit /b 1
@@ -69,7 +80,7 @@ if "%TRAINING_BASE%"=="1" (
 exit /b 0
 
 :help
-echo Usage: models.cmd [--variant medium^|small-music^|small-sfx] [--encoding f16^|f32^|q4_k_m^|q5_k_m^|q8_0] [--training-base] [--namespace HF_USER] [--out DIR] [--dry-run]
+echo Usage: models.cmd [--variant medium^|small-music^|small-sfx] [--encoding f16^|f32^|q4_k_m^|q5_k_m^|q8_0] [--t5-encoding f16^|f32^|q8_0] [--training-base] [--namespace HF_USER] [--out DIR] [--dry-run]
 exit /b 0
 
 :dl

--- a/models.sh
+++ b/models.sh
@@ -2,6 +2,7 @@
 # Download the sa3.cpp GGUF model set from HuggingFace (public repos) with curl — no Python.
 #
 # Usage: ./models.sh [--variant medium|small-music|small-sfx] [--encoding f16|f32|q4_k_m|q5_k_m|q8_0]
+#                    [--t5-encoding f16|f32|q8_0]
 #                    [--training-base] [--namespace <hf-user>] [--out DIR] [--dry-run]
 #   default: medium f16 into ./models
 #
@@ -12,6 +13,8 @@ set -eu
 
 VARIANT="medium"
 ENCODING="f16"
+# The text encoder is resolved apart from the DiT/SAME: F16 is equivalent to F32 at half the size.
+T5_ENCODING="f16"
 NAMESPACE="thepatch"
 OUT="models"
 TRAINING_BASE=0
@@ -21,6 +24,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --variant)   VARIANT="$2"; shift ;;
     --encoding)  ENCODING="$2"; shift ;;
+    --t5-encoding) T5_ENCODING="$2"; shift ;;
     --namespace) NAMESPACE="$2"; shift ;;
     --out)       OUT="$2"; shift ;;
     --training-base) TRAINING_BASE=1 ;;
@@ -52,6 +56,12 @@ ENC=$(printf '%s' "$ENCODING" | tr '[:lower:]' '[:upper:]')   # F16 / F32
 # backend. Q5_K_M/Q8_0 bases are not published, so those requests pull an F16 base DiT instead. The
 # [fetch] lines below show which one was resolved.
 BASE_ENC="$ENC"
+case "$T5_ENCODING" in
+  f16|F16)   T5_ENC="F16" ;;
+  f32|F32)   T5_ENC="F32" ;;
+  q8_0|Q8_0) T5_ENC="Q8_0" ;;
+  *) echo "unknown --t5-encoding '$T5_ENCODING' (expected f16|f32|q8_0)" >&2; exit 2 ;;
+esac
 case "$ENC" in
   F16|F32|Q4_K_M) ;;
   Q5_K_M|Q8_0) BASE_ENC="F16" ;;
@@ -85,7 +95,7 @@ if [ "$TRAINING_BASE" -eq 1 ]; then
 fi
 dl "$VAR_REPO" "$BASE-$SAME-v1.0-$ENC.gguf"
 dl "$VAR_REPO" "$BASE-conditioner-v1.0-F32.gguf"
-dl "$SHARED"   "t5gemma-b-b-ul2-encoder-0.3B-v1.0-F32.gguf"
+dl "$SHARED"   "t5gemma-b-b-ul2-encoder-0.3B-v1.0-$T5_ENC.gguf"
 dl "$SHARED"   "t5gemma-b-b-ul2-v1.0-vocab.gguf"
 
 if [ "$TRAINING_BASE" -eq 1 ]; then

--- a/src/libsa3.cpp
+++ b/src/libsa3.cpp
@@ -148,7 +148,8 @@ static int sa3_generate_impl(sa3_context* ctx, const sa3_request* req, const sa3
       catch (...)                     { set_err(err, err_len, "unknown error"); return 10; }
 }
 
-static sa3_context* sa3_init_impl(const sa3_config* cfg, int cpu_threads, const char* device, char* err, int err_len) {
+static sa3_context* sa3_init_impl(const sa3_config* cfg, int cpu_threads, const char* device,
+                                  const char* text_encoding, char* err, int err_len) {
     try {
         if (cpu_threads < 0) { set_err(err, err_len, "cpu_threads must be positive"); return nullptr; }
         std::string models_dir = cfg && cfg->models_dir ? cfg->models_dir : "";
@@ -157,8 +158,10 @@ static sa3_context* sa3_init_impl(const sa3_config* cfg, int cpu_threads, const 
         const std::string encoding = cfg && cfg->encoding ? cfg->encoding : "f16";
         const std::string adir     = cfg && cfg->adapters_dir ? cfg->adapters_dir : models_dir;
 
+        const std::string tenc = text_encoding ? text_encoding : "";
+
         sa3::ModelPaths mp; std::string rerr;
-        if (!sa3::ModelPaths::resolve(models_dir, variant, encoding, mp, rerr)) { set_err(err, err_len, rerr); return nullptr; }
+        if (!sa3::ModelPaths::resolve(models_dir, variant, encoding, tenc, mp, rerr)) { set_err(err, err_len, rerr); return nullptr; }
 
         auto ctx = std::make_unique<sa3_context>();
         ctx->paths = mp;
@@ -175,12 +178,13 @@ static sa3_context* sa3_init_impl(const sa3_config* cfg, int cpu_threads, const 
 extern "C" {
 
 SA3_API sa3_context* sa3_init(const sa3_config* cfg, char* err, int err_len) {
-    return sa3_init_impl(cfg, 0, nullptr, err, err_len);
+    return sa3_init_impl(cfg, 0, nullptr, nullptr, err, err_len);
 }
 
 SA3_API sa3_context* sa3_init_ex(const sa3_config_ex* cfg, char* err, int err_len) {
     return sa3_init_impl(cfg ? &cfg->config : nullptr, cfg ? cfg->cpu_threads : 0,
-                         cfg ? cfg->device : nullptr, err, err_len);
+                         cfg ? cfg->device : nullptr,
+                         cfg ? cfg->text_encoder_encoding : nullptr, err, err_len);
 }
 
 SA3_API int sa3_generate(sa3_context* ctx, const sa3_request* req, sa3_audio* out, char* err, int err_len) {
@@ -240,6 +244,7 @@ SA3_API int sa3_train(const sa3_train_config* cfg, const sa3_train_hooks* hooks,
         str(cfg->models_dir,     tc.models_dir);
         str(cfg->variant,        tc.model_variant);
         str(cfg->encoding,       tc.encoding);
+        str(cfg->text_encoder_encoding, tc.text_encoding);
         str(cfg->dataset_dir,    tc.dataset_dir);
         str(cfg->output_dir,     tc.output_dir);
         str(cfg->latents_dir,    tc.latents_dir);

--- a/src/libsa3.h
+++ b/src/libsa3.h
@@ -218,7 +218,6 @@ typedef struct {
     const char* models_dir;      /* NULL -> $SA3_MODELS_DIR, else "models" */
     const char* variant;         /* NULL -> "medium" ("medium" | "small-music" | "small-sfx") */
     const char* encoding;        /* NULL -> "f16"; quantized bases ("q4_k_m", "q8_0", ...) train too */
-    const char* text_encoder_encoding; /* NULL -> auto (prefers F16); resolved apart from `encoding` */
     const char* dataset_dir;     /* REQUIRED */
     const char* output_dir;      /* NULL -> train-runs/<dataset name> */
     const char* latents_dir;     /* optional pre-encoded latents; skips audio decode entirely */
@@ -240,6 +239,14 @@ typedef struct {
     int     cpu_threads;         /* 0 -> SA3_THREADS/default; CPU backend only */
     int     pre_encode;          /* 1 = encode the dataset to latents once up front */
     int64_t seed;                /* 0 -> 42 */
+
+    /* Text-encoder precision, resolved apart from `encoding` -- the useful combination is a
+     * quantized DiT with an F16 encoder. NULL -> auto (prefers F16, never a quantized tier on
+     * its own). Logically it belongs next to `encoding`, but it sits here because NEW FIELDS GO
+     * AT THE END: a host compiled against an older libsa3 passes a shorter struct, and an
+     * appended field costs it only this one value, where an inserted one silently shifts every
+     * field after it. */
+    const char* text_encoder_encoding;
 } sa3_train_config;
 
 /* One optimizer update. Pointers are valid only for the duration of the callback. */

--- a/src/libsa3.h
+++ b/src/libsa3.h
@@ -47,6 +47,10 @@ typedef struct {
     sa3_config config;
     int cpu_threads;
     const char* device;
+    /* Text-encoder precision, resolved independently of config.encoding -- the useful combination is
+     * a quantized DiT with an F16 encoder. NULL/"" -> auto, which prefers F16 (equivalent to F32 for
+     * this encoder) and never picks a quantized tier on its own. */
+    const char* text_encoder_encoding;
 } sa3_config_ex;
 
 /* Optional progress callback. fraction is overall 0..1 (UI does *100); stage is
@@ -214,6 +218,7 @@ typedef struct {
     const char* models_dir;      /* NULL -> $SA3_MODELS_DIR, else "models" */
     const char* variant;         /* NULL -> "medium" ("medium" | "small-music" | "small-sfx") */
     const char* encoding;        /* NULL -> "f16"; quantized bases ("q4_k_m", "q8_0", ...) train too */
+    const char* text_encoder_encoding; /* NULL -> auto (prefers F16); resolved apart from `encoding` */
     const char* dataset_dir;     /* REQUIRED */
     const char* output_dir;      /* NULL -> train-runs/<dataset name> */
     const char* latents_dir;     /* optional pre-encoded latents; skips audio decode entirely */

--- a/src/sa3_pipeline.h
+++ b/src/sa3_pipeline.h
@@ -414,8 +414,13 @@ inline bool ModelPaths::resolve(const std::string& md, const std::string& varian
     out.dit  = one(dit_pre,  "-" + ENC + ".gguf",  "DiT");
     out.same = one(same_pre, "-" + ENC + ".gguf",  "SAME");
     if (!err.empty()) {
-        std::string alt = out.dit.empty() ? alternatives(dit_pre) : alternatives(same_pre);
-        if (!alt.empty()) err += " [available for this variant: " + alt + " — pass --encoding for one of those]";
+        // The --encoding hint belongs only to a DiT/SAME miss. The text encoder resolves on its own
+        // axis (--t5-encoding), so appending it to a text-encoder failure told the user to change the
+        // one flag that cannot fix it -- and named the DiT tiers as if they were encoder tiers.
+        if (out.dit.empty() || out.same.empty()) {
+            std::string alt = out.dit.empty() ? alternatives(dit_pre) : alternatives(same_pre);
+            if (!alt.empty()) err += " [available for this variant: " + alt + " — pass --encoding for one of those]";
+        }
         err += " in " + md + "/ (run: python tools/download_models.py --variant " + variant + ")";
     }
     return err.empty();

--- a/src/sa3_pipeline.h
+++ b/src/sa3_pipeline.h
@@ -285,6 +285,13 @@ struct ModelPaths {
     // + a message in `err` if a required file is missing (so the caller can surface a friendly hint).
     static bool resolve(const std::string& models_dir, const std::string& variant,
                         const std::string& encoding, ModelPaths& out, std::string& err);
+
+    // As above, but also picks the text encoder's encoding. `text_encoding` empty => auto
+    // (see text_encoder_auto_priority). The encoder is published separately from the DiT/SAME
+    // because the useful combination is a quantized DiT with an F16 encoder.
+    static bool resolve(const std::string& models_dir, const std::string& variant,
+                        const std::string& encoding, const std::string& text_encoding,
+                        ModelPaths& out, std::string& err);
 };
 
 // True if the DiT's projection weights are stored as a quantized type. Checked on a weight
@@ -298,8 +305,78 @@ inline bool dit_base_is_quantized(const GgufModel& dit) {
     return false;
 }
 
+// Which text-encoder encoding to take when the caller did not name one. F16 is measurably
+// equivalent to F32 for this encoder -- max |err| 1.8e-6 on the cross-attention conditioning, and
+// generated audio is often bit-identical -- so preferring it is a size win (1074 -> 537 MiB), not a
+// fidelity substitution. Quantized tiers ARE a real tradeoff and are never auto-selected; they are
+// used only when asked for by name, or when nothing else is present.
+inline const std::vector<std::string>& text_encoder_auto_priority() {
+    static const std::vector<std::string> v = {"F16", "F32"};
+    return v;
+}
+
+// Resolve the shared T5Gemma text encoder. Named `t5gemma-b-b-ul2-encoder-<size>-<ver>-<ENC>.gguf`,
+// but historically published only as F32 and matched by bare prefix -- so an installation may hold a
+// file whose name carries no encoding this build knows. The order here keeps every one of those
+// working:
+//   1. an explicit request resolves EXACTLY, like --encoding does, or fails saying what is present;
+//   2. otherwise take the first of text_encoder_auto_priority() that exists;
+//   3. otherwise fall back to the bare-prefix glob, which is what older single-file installs hit.
+// Step 3 still refuses an ambiguous match rather than picking whichever the directory yielded first.
+inline std::string resolve_text_encoder(const std::string& md, const std::string& text_encoding,
+                                        std::string& err) {
+    const std::string prefix = "t5gemma-b-b-ul2-encoder-";
+    auto present = [&](const std::string& enc) {
+        return resolve_one(md, prefix, "-" + enc + ".gguf");
+    };
+    auto available = [&]() {
+        std::string alt;
+        for (const std::string& e : encoding_labels())
+            if (!present(e).empty()) alt += (alt.empty() ? "" : ", ") + e;
+        return alt;
+    };
+
+    if (!text_encoding.empty()) {
+        const std::string ENC = encoding_suffix(text_encoding);
+        if (ENC.empty()) {
+            err += (err.empty() ? "" : "; ") +
+                   ("unknown text-encoder encoding '" + text_encoding + "'");
+            return "";
+        }
+        std::string p = present(ENC);
+        if (p.empty()) {
+            std::string msg = "no text encoder (" + prefix + "*-" + ENC + ".gguf)";
+            const std::string alt = available();
+            if (!alt.empty()) msg += " [available: " + alt + "]";
+            err += (err.empty() ? "" : "; ") + msg;
+        }
+        return p;
+    }
+
+    for (const std::string& enc : text_encoder_auto_priority()) {
+        std::string p = present(enc);
+        if (!p.empty()) return p;
+    }
+
+    bool ambiguous = false;
+    std::string p = resolve_one(md, prefix, ".gguf", &ambiguous);
+    if (p.empty())
+        err += (err.empty() ? "" : "; ") + ("no text encoder (" + prefix + "*.gguf)");
+    else if (ambiguous)
+        err += (err.empty() ? "" : "; ") +
+               ("multiple files match " + prefix + "*.gguf and none is a known encoding; "
+                "remove the ones you do not want");
+    return p;
+}
+
 inline bool ModelPaths::resolve(const std::string& md, const std::string& variant,
                                 const std::string& encoding, ModelPaths& out, std::string& err) {
+    return resolve(md, variant, encoding, "", out, err);
+}
+
+inline bool ModelPaths::resolve(const std::string& md, const std::string& variant,
+                                const std::string& encoding, const std::string& text_encoding,
+                                ModelPaths& out, std::string& err) {
     // The requested encoding is resolved EXACTLY: this project's whole point is numeric parity,
     // so silently substituting a different precision than the caller asked for is not acceptable.
     // A missing file is an error naming what was looked for and what else is present.
@@ -309,9 +386,14 @@ inline bool ModelPaths::resolve(const std::string& md, const std::string& varian
         return false;
     }
     auto one = [&](const std::string& prefix, const std::string& suffix, const char* what) {
-        std::string p = resolve_one(md, prefix, suffix);
+        bool ambiguous = false;
+        std::string p = resolve_one(md, prefix, suffix, &ambiguous);
         if (p.empty())
             err += (err.empty() ? "" : "; ") + ("no " + std::string(what) + " (" + prefix + "*" + suffix + ")");
+        else if (ambiguous)
+            err += (err.empty() ? "" : "; ") +
+                   ("multiple files match " + prefix + "*" + suffix + " for the " + what +
+                    "; remove the ones you do not want");
         return p;
     };
     // Report which other encodings DO exist, so "no DiT (...-Q4_KM.gguf)" is actionable.
@@ -325,7 +407,7 @@ inline bool ModelPaths::resolve(const std::string& md, const std::string& varian
         return alt;
     };
     out.tok  = one("t5gemma-b-b-ul2-v1.0-vocab",             ".gguf",            "tokenizer");
-    out.t5   = one("t5gemma-b-b-ul2-encoder-",               ".gguf",            "encoder");
+    out.t5   = resolve_text_encoder(md, text_encoding, err);
     out.cond = one("stable-audio-3-" + variant + "-conditioner-", ".gguf",       "conditioner");
     const std::string dit_pre  = "stable-audio-3-" + variant + "-dit-";
     const std::string same_pre = "stable-audio-3-" + variant + "-same-";

--- a/src/train_config.h
+++ b/src/train_config.h
@@ -20,6 +20,9 @@ namespace sa3 {
 struct TrainConfig {
     std::string model_variant = "medium";
     std::string encoding = "f16";
+    // Text-encoder precision, resolved independently of `encoding` -- the useful combination is a
+    // quantized DiT with an F16 encoder. Empty => auto (prefers F16, see text_encoder_auto_priority).
+    std::string text_encoding;
     std::string models_dir = "models";
     std::string tok_path;
     std::string t5_path;
@@ -244,6 +247,7 @@ inline bool train_set_config_value(TrainConfig& c, const std::string& key, const
 
     if      (key == "model" || key == "model_variant") c.model_variant = value;
     else if (key == "encoding") c.encoding = value;
+    else if (key == "t5-encoding" || key == "t5_encoding") c.text_encoding = value;
     else if (key == "models-dir" || key == "models_dir") c.models_dir = value;
     else if (key == "tok" || key == "tok_path") c.tok_path = value;
     else if (key == "t5" || key == "t5_path") c.t5_path = value;
@@ -525,6 +529,7 @@ inline std::string train_config_usage(const char* argv0) {
        << "              --steps N (alias: --max-steps; default 10000)\n"
        << "              --resume adapter-step-N.gguf|trainer-state-step-N.gguf (N -> --steps total)\n"
        << "              --encoding f16|f32|q4_k_m|q5_k_m|q5_k|q8_0 (default f16; quantized bases train)\n"
+       << "              --t5-encoding ENC (text encoder precision; default auto, prefers F16)\n"
        << "              --device cpu|<gpu> (default: SA3_DEVICE, else GPU if available)\n"
        << "adapter: --adapter-type lora|dora-rows|dora-cols|bora|*-xs --rank N --alpha F (default: = rank)\n"
        << "          --lora-scope full|core (full=228 weights, core=168 per-block projections)\n"

--- a/src/train_model_paths.h
+++ b/src/train_model_paths.h
@@ -13,7 +13,8 @@ inline bool resolve_train_model_paths(const TrainConfig& cfg, ModelPaths& paths,
     const bool has_explicit_required =
         !cfg.tok_path.empty() && !cfg.t5_path.empty() && !cfg.dit_path.empty() && !cfg.same_path.empty();
     if (!has_explicit_required) {
-        if (!ModelPaths::resolve(cfg.models_dir, cfg.model_variant, cfg.encoding, paths, err)) return false;
+        if (!ModelPaths::resolve(cfg.models_dir, cfg.model_variant, cfg.encoding, cfg.text_encoding,
+                                 paths, err)) return false;
     }
 
     // Stable Audio 3 adapters are trained against the distinct base DiT and applied to the

--- a/tests/model_artifacts_test.py
+++ b/tests/model_artifacts_test.py
@@ -12,7 +12,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
-from model_artifacts import build_download_plan, dit_filename, dit_identity
+from model_artifacts import (TEXT_ENCODER_ENCODINGS, build_download_plan, dit_filename,
+                             dit_identity, text_encoder_filename)
 from stage_training_base_repos import notice_text
 
 
@@ -34,6 +35,31 @@ class ModelArtifactsTest(unittest.TestCase):
         self.assertEqual(plan[0][0], "thepatch/stable-audio-3-medium-GGUF")
         self.assertIn("stable-audio-3-medium-dit-1.5B-v1.0-F16.gguf", plan[0][1])
         self.assertEqual(plan[-1][0], "thepatch/t5gemma-b-b-ul2-GGUF")
+
+    def test_text_encoder_defaults_to_f16(self):
+        # F16 is equivalent to F32 for this encoder at half the size, so it is what a plain
+        # download gets; the shared repo's file list is the thing that decides it.
+        plan = build_download_plan("thepatch", "medium", "f16")
+        self.assertEqual(plan[-1][0], "thepatch/t5gemma-b-b-ul2-GGUF")
+        self.assertIn("t5gemma-b-b-ul2-encoder-0.3B-v1.0-F16.gguf", plan[-1][1])
+        self.assertIn("t5gemma-b-b-ul2-v1.0-vocab.gguf", plan[-1][1])
+
+    def test_text_encoder_encoding_is_independent_of_the_dit(self):
+        # The combination worth having on a small device: quantized DiT, F16 encoder.
+        plan = build_download_plan("thepatch", "medium", "q4_k_m", text_encoding="f16")
+        self.assertIn("stable-audio-3-medium-dit-1.5B-v1.0-Q4_K_M.gguf", plan[0][1])
+        self.assertIn("t5gemma-b-b-ul2-encoder-0.3B-v1.0-F16.gguf", plan[-1][1])
+
+    def test_every_published_text_encoder_encoding_resolves(self):
+        for enc in TEXT_ENCODER_ENCODINGS:
+            plan = build_download_plan("thepatch", "medium", "f16", text_encoding=enc)
+            self.assertIn(f"t5gemma-b-b-ul2-encoder-0.3B-v1.0-{enc}.gguf", plan[-1][1])
+
+    def test_q4_text_encoder_is_not_published(self):
+        # Excluded on measurement: slower than F32 for the encoder AND far worse prompt fidelity.
+        with self.assertRaises(ValueError) as ctx:
+            text_encoder_filename("q4_k_m")
+        self.assertIn("f16", str(ctx.exception))
 
     def test_training_plan_adds_base_dit(self):
         plan = build_download_plan("thepatch", "small-sfx", "f32", training_base=True)

--- a/tools/download_models.py
+++ b/tools/download_models.py
@@ -18,7 +18,8 @@ The published default namespace is ``thepatch``; override it with --namespace.
 """
 import argparse, importlib.util, os, sys
 
-from model_artifacts import ENCODINGS, VARIANTS, build_download_plan
+from model_artifacts import (ENCODINGS, TEXT_ENCODER_DEFAULT, TEXT_ENCODER_ENCODINGS,
+                             VARIANTS, build_download_plan)
 
 DEFAULT_NAMESPACE = "thepatch"
 
@@ -49,6 +50,9 @@ def main():
     ap.add_argument("--variant", default="medium", choices=list(VARIANTS))
     ap.add_argument("--encoding", default="f16", choices=[e.lower() for e in ENCODINGS],
                     help="weight encoding for DiT + SAME (default f16, the production path)")
+    ap.add_argument("--t5-encoding", default=TEXT_ENCODER_DEFAULT.lower(),
+                    choices=[e.lower() for e in TEXT_ENCODER_ENCODINGS],
+                    help="text encoder encoding (default f16, equivalent to f32 at half the size)")
     ap.add_argument("--namespace", default=DEFAULT_NAMESPACE, help="HuggingFace org/user")
     ap.add_argument("--out", default="models", help="output dir (default ./models)")
     ap.add_argument("--training-base", action="store_true",
@@ -57,7 +61,8 @@ def main():
                     help="print the resolved repo/file plan and exit, downloading nothing")
     args = ap.parse_args()
 
-    plan = build_download_plan(args.namespace, args.variant, args.encoding, args.training_base)
+    plan = build_download_plan(args.namespace, args.variant, args.encoding, args.training_base,
+                               text_encoding=args.t5_encoding)
 
     if args.dry_run:
         for repo, files in plan:

--- a/tools/model_artifacts.py
+++ b/tools/model_artifacts.py
@@ -24,11 +24,26 @@ STABILITY_LICENSE_SHA256 = "d6f6b1a4dce5c852bd6d7d9482d002baf0ccdb71e662250b73be
 
 SHARED_REPO = "t5gemma-b-b-ul2-GGUF"
 
-# Encodings the DiT and SAME are published in. The conditioner, text encoder and tokenizer are
-# always F32 -- they are small and quality-critical, so there is nothing to gain by quantizing them.
+# Encodings the DiT and SAME are published in. The conditioner and tokenizer are always F32 --
+# those two really are small (a 793 KiB conditioner, a 14 MiB vocab), so there is nothing to gain.
 FLOAT_ENCODINGS = ("F16", "F32")
 QUANT_ENCODINGS = ("Q4_K_M", "Q5_K_M", "Q8_0")
 ENCODINGS = FLOAT_ENCODINGS + QUANT_ENCODINGS
+
+# The text encoder is not small: at F32 it is 1074 MiB, the largest file in the set and bigger than
+# a small-music DiT. Measured on small-music/Metal against an F32 control, swapping only the encoder:
+#
+#   F16   537 MiB  conditioning cos 1.000000000, generated-audio cos 0.999971  -- free
+#   Q8_0  285 MiB  conditioning cos 0.999789,    generated-audio cos 0.991496  -- a real tradeoff
+#   Q4_K_M 206 MiB conditioning cos 0.977908,    generated-audio cos 0.797692  -- not shipped
+#
+# Q4_K_M is excluded on evidence, not caution: it is 11.8% SLOWER than F32 for the encoder (the T5
+# forward is too small to amortize dequant, unlike the DiT) while doing real damage to prompt
+# fidelity, so Q8_0 dominates it outright. Note that training loss is nearly blind to all of this --
+# Q4_K_M moved mean loss by 0.02% over 100 matched steps. Validate an encoder with conditioning
+# cosine (SA3_DUMP_COND) and generated audio, never with a loss curve.
+TEXT_ENCODER_ENCODINGS = ("F16", "F32", "Q8_0")
+TEXT_ENCODER_DEFAULT = "F16"
 
 # Training bases are published F16, F32 and Q4_K_M. Training on a quantized base works on every
 # backend -- CPU, CUDA, Vulkan and Metal -- because the functional adapter path keeps the frozen base
@@ -68,7 +83,18 @@ def dit_filename(variant, encoding, training_base=False):
     return f"{identity['basename']}-{size}-{VERSION}-{encoding.upper()}.gguf"
 
 
-def build_download_plan(namespace, variant, encoding, training_base=False):
+def text_encoder_filename(encoding):
+    """Return the published text-encoder filename for an encoding."""
+    enc = encoding.upper()
+    if enc not in TEXT_ENCODER_ENCODINGS:
+        raise ValueError(
+            f"unsupported text-encoder encoding: {encoding} "
+            f"(expected one of {', '.join(e.lower() for e in TEXT_ENCODER_ENCODINGS)})"
+        )
+    return f"t5gemma-b-b-ul2-encoder-0.3B-{VERSION}-{enc}.gguf"
+
+
+def build_download_plan(namespace, variant, encoding, training_base=False, text_encoding=None):
     """Return ``[(repo_id, [filenames...]), ...]`` for download_models.py.
 
     Training needs the inference components as well as the base DiT, so
@@ -107,7 +133,7 @@ def build_download_plan(namespace, variant, encoding, training_base=False):
         (
             f"{namespace}/{SHARED_REPO}",
             [
-                f"t5gemma-b-b-ul2-encoder-0.3B-{VERSION}-F32.gguf",
+                text_encoder_filename(text_encoding or TEXT_ENCODER_DEFAULT),
                 f"t5gemma-b-b-ul2-{VERSION}-vocab.gguf",
             ],
         )

--- a/tools/sa3-generate.cpp
+++ b/tools/sa3-generate.cpp
@@ -33,6 +33,7 @@ int main(int argc, char** argv) {
     const char* cond_p = nullptr;            // per-variant conditioner sidecar gguf (optional; falls back to --t5 if bundled)
     const char* model_variant = nullptr;     // --model: resolve the 5 base ggufs by naming convention
     const char* encoding = "f16";            // --encoding f16|f32|q4_k_m|q5_k_m|q5_k|q8_0 (which DiT/SAME precision --model picks)
+    const char* t5_encoding = "";            // --t5-encoding: text encoder precision; "" = auto (prefers F16)
     const char* env_md = getenv("SA3_MODELS_DIR");
     const char* models_dir = (env_md && *env_md) ? env_md : "models";  // --models-dir / SA3_MODELS_DIR
     const char* env_ad = getenv("SA3_ADAPTERS_DIR");
@@ -60,6 +61,7 @@ int main(int argc, char** argv) {
     for (int i = 1; i < argc; i++) {
         if      (!strcmp(argv[i], "--model")  && i+1 < argc) model_variant = argv[++i];
         else if (!strcmp(argv[i], "--encoding") && i+1 < argc) encoding = argv[++i];
+        else if (!strcmp(argv[i], "--t5-encoding") && i+1 < argc) t5_encoding = argv[++i];
         else if (!strcmp(argv[i], "--models-dir") && i+1 < argc) models_dir = argv[++i];
         else if (!strcmp(argv[i], "--adapters-dir") && i+1 < argc) adapters_dir = argv[++i];
         else if (!strcmp(argv[i], "--tok")    && i+1 < argc) tok_p = argv[++i];
@@ -156,7 +158,15 @@ int main(int argc, char** argv) {
             resolved.push_back(std::move(p)); slot = resolved.back().c_str();
         };
         fill(tok_p,  "t5gemma-b-b-ul2-v1.0-vocab",             ".gguf");
-        fill(t5_p,   "t5gemma-b-b-ul2-encoder-",               ".gguf");        // shared encoder (F32)
+        if (!t5_p) {   // shared encoder; --t5-encoding picks the precision, "" = auto (prefers F16)
+            std::string terr, p = sa3::resolve_text_encoder(md, t5_encoding, terr);
+            if (p.empty()) {
+                fprintf(stderr, "[sa3] --model %s: %s in %s/ (run: python tools/download_models.py --variant %s)\n",
+                        mv.c_str(), terr.c_str(), md.c_str(), mv.c_str());
+                exit(1);
+            }
+            resolved.push_back(std::move(p)); t5_p = resolved.back().c_str();
+        }
         fill(cond_p, "stable-audio-3-" + mv + "-conditioner-", ".gguf");        // F32
         fill(dit_p,  "stable-audio-3-" + mv + "-dit-",  "-" + ENC + ".gguf");
         fill(same_p, "stable-audio-3-" + mv + "-same-", "-" + ENC + ".gguf");
@@ -178,6 +188,7 @@ int main(int argc, char** argv) {
     const bool inpaint = (inpaint_start >= 0.0f || inpaint_end >= 0.0f);   // inpaint mode (needs --init source)
     if (!tok_p || !t5_p || !dit_p || !same_p) {
         fprintf(stderr, "usage: sa3-generate (--model medium|small-music|small-sfx [--encoding f16|f32|q4_k_m|q5_k_m|q5_k|q8_0] [--models-dir DIR]\n"
+                        "                     [--t5-encoding ENC  text encoder precision; default auto, prefers F16]\n"
                         "                     | --tok <f> --t5 <f> --cond <f> --dit <f> --same <f>)\n"
                         "                     --prompt \"...\" [--lora NAME|PATH [--lora-strength S]]... [--duration SEC | --frames N] [--steps N] [--threads N] [--seed S]\n"
                         "                     [--dist-shift LogSNR|Flux|Full|None [--dist-shift-params p1,p2,p3,p4]] [--duration-padding SEC]\n"

--- a/tools/sa3-server.cpp
+++ b/tools/sa3-server.cpp
@@ -49,6 +49,10 @@ std::unique_ptr<sa3::Pipeline> g_pipe;    // loaded lazily on first generate; fr
 std::atomic<bool> g_loaded{false};        // lock-free view for /health (won't block during a gen)
 std::string g_variant   = "medium";
 std::string g_encoding  = "f16";
+// Text-encoder precision, resolved apart from g_encoding -- the combination worth having on a
+// small box is a quantized DiT with an F16 encoder. Empty => auto (prefers F16, and never a
+// quantized tier on its own). See docs/DISTRIBUTION.md.
+std::string g_t5_encoding;
 std::string g_models_dir;
 std::string g_adapters_dir;
 std::string g_prompts_dir;
@@ -555,7 +559,8 @@ void jobs_prune() {
 bool ensure_loaded(std::string& err) {
     if (g_pipe && g_pipe->loaded()) { g_loaded = true; return true; }
     sa3::ModelPaths mp;
-    if (!sa3::ModelPaths::resolve(g_models_dir, g_variant, g_encoding, mp, err)) return false;
+    if (!sa3::ModelPaths::resolve(g_models_dir, g_variant, g_encoding, g_t5_encoding, mp, err))
+        return false;
     try {
         g_pipe = std::make_unique<sa3::Pipeline>();
         g_pipe->load(mp, g_cpu_threads);
@@ -856,6 +861,7 @@ int main(int argc, char** argv) {
         else if (a == "--port")         port = atoi(next("8006"));
         else if (a == "--model")        g_variant = next("medium");
         else if (a == "--encoding")     g_encoding = next("f16");
+        else if (a == "--t5-encoding")  g_t5_encoding = next("");
         else if (a == "--models-dir")   g_models_dir = next("models");
         else if (a == "--adapters-dir") g_adapters_dir = next("");
         else if (a == "--prompts-dir")  g_prompts_dir = next("prompts");
@@ -924,7 +930,9 @@ int main(int argc, char** argv) {
     svr.Get("/health", [](const httplib::Request&, httplib::Response& res) {
         const bool loaded = g_loaded.load();   // atomic: never blocks behind an in-flight generation
         std::string body = "{\"status\":\"ok\",\"model\":\"" + g_variant + "\",\"encoding\":\"" +
-                           g_encoding + "\",\"loaded\":" + (loaded ? "true" : "false") +
+                           g_encoding + "\",\"t5_encoding\":\"" +
+                           (g_t5_encoding.empty() ? "auto" : g_t5_encoding) +
+                           "\",\"loaded\":" + (loaded ? "true" : "false") +
                            ",\"loudness_defaults\":" + loudness_params_json(sa3::loudness_defaults_from_env()) + "}";
         res.set_content(body, "application/json");
     });
@@ -1237,8 +1245,10 @@ int main(int argc, char** argv) {
         res.set_content(body, "application/json");
     });
 
-    fprintf(stderr, "[sa3-server] http://%s:%d  model=%s/%s  models=%s  adapters=%s  source_loras=%s  prompts=%s  audio_in=%s  web=%s  (async /poll_status; frugal default)\n",
-            host.c_str(), port, g_variant.c_str(), g_encoding.c_str(), g_models_dir.c_str(), adir.c_str(), sldir.c_str(), pdir.c_str(), aidir.c_str(),
+    fprintf(stderr, "[sa3-server] http://%s:%d  model=%s/%s  t5=%s  models=%s  adapters=%s  source_loras=%s  prompts=%s  audio_in=%s  web=%s  (async /poll_status; frugal default)\n",
+            host.c_str(), port, g_variant.c_str(), g_encoding.c_str(),
+            g_t5_encoding.empty() ? "auto" : g_t5_encoding.c_str(),
+            g_models_dir.c_str(), adir.c_str(), sldir.c_str(), pdir.c_str(), aidir.c_str(),
             g_web_dir.empty() ? "(none)" : g_web_dir.c_str());
     if (!svr.listen(host.c_str(), port)) {
         fprintf(stderr, "[sa3-server] failed to bind %s:%d\n", host.c_str(), port);


### PR DESCRIPTION
At F32 the T5 encoder is 1074 MiB — the largest file in the set, bigger than a small-music
DiT. It was published F32-only, resolved by bare prefix with no encoding in the name.

Measured on small-music/Metal, swapping only the encoder:

| encoder | size | conditioning cos | audio cos | train peak |
|---|---:|---:|---:|---:|
| F32 | 1074 MiB | — | — | 2.28 GiB |
| F16 | 537 MiB | 1.000000000 | 0.999971 | 1.78 GiB |
| Q8_0 | 285 MiB | 0.999789 | 0.991496 | 1.52 GiB |
| Q4_K_M | 206 MiB | 0.977908 | 0.797692 | 1.46 GiB |

F16 is the new download default. Q8_0 is offered. Q4_K_M is not published: for this encoder
it is 11.8% slower than F32 and drops audio cosine to 0.798.

Also fixes a latent bug — `resolve()` never passed `resolve_one`'s ambiguous flag, so two
matching files meant picking whichever the directory iterator yielded first.

Note for review: Q4_K_M moved mean training loss by 0.02% while producing that 0.798. Loss
curves are close to blind here; use conditioning cosine (`SA3_DUMP_COND`) and audio.

---

## PC validation (done — this was the merge blocker)

**The F16 and Q8_0 encoder GGUFs are built and live** in
[`thepatch/t5gemma-b-b-ul2-GGUF`](https://huggingface.co/thepatch/t5gemma-b-b-ul2-GGUF)
at 537 MiB and 285 MiB, matching the table above. All three encoder URLs return 200, so
`--t5-encoding f16` no longer 404s a fresh install. The model card, which still advertised
F32 as the only encoder, was updated and republished.

Validated on the PC (CUDA, RTX 5070 Laptop):

- **Resolver** — auto picks F16 > F32, never auto-selects a quantized tier when a float one is
  present, falls back correctly when only Q8_0 exists, and legacy bare-name installs still
  resolve. Confirmed by byte-matching conditioning dumps against known references.
- **Training** — all four DiT×T5 combinations train; the DiT resolves to the base tier while the
  encoder resolves independently. Run snapshots record `resolved_t5`, so runs stay reproducible.
- **LoRA serve** — all 8 of (f16-trained, q4-trained) × (f16, q4_k_m base) × (f16, q8_0 encoder)
  generate, and produce 8 distinct outputs, so no flag is silently ignored.
- Encoder quality on CUDA: F16 cond cos 0.999995 / audio 0.999848; Q8_0 0.999547 / 0.999108.
- 14/14 `model_artifacts_test.py`, full CUDA build clean.

### added while validating

- **`sa3-server` had no `--t5-encoding`** — the only entry point without it, so a tight-memory
  box could never ask for the Q8_0 encoder. Added, reported in the banner and `/health`,
  documented in `docs/SERVER.md`, verified end to end through `/generate`.
- **The resolver misdirected on text-encoder failures.** The "pass `--encoding` for one of those"
  hint was appended whenever anything failed, so a missing text encoder named the DiT tiers as if
  they were encoder tiers and pointed at the one flag that cannot fix it. Now attached only to a
  DiT/SAME miss.
- **`text_encoder_encoding` moved to the end of `sa3_train_config`.** It had been inserted between
  `encoding` and `dataset_dir`, so a host compiled against the previous header would have had every
  pointer after `encoding` shift by one slot. `sa3_config_ex` already appended its copy at the end.
- **Training time is unaffected by encoder precision.** `t5_cond` is 9 ms of a 1070 ms medium step
  on CUDA (0.84%), and Q8_0 is 1 ms faster there; pooled step time differs by 0.05%. Measured ABBA,
  because total step time drifts 1062 → 1080 ms as the GPU heats and A-then-B would have reported
  Q8_0 as ~1.3% slower. Written up in `docs/TRAINING.md`.

A 2500-step ratatat DoRA comparison (q8-trained vs f16-trained, plus quantized-at-both-ends) is
running to check for audible quality loss. It is not a blocker for this PR — it measures whether to
*recommend* Q8_0 for training, not whether the plumbing is correct.
