### PR TITLE
build: iOS library target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ build-cpu-variants/
 build-cuda/
 build-vulkan/
 build-hip/
+build-ios-sim/
+build-ios-sim-x64/
+build-ios-dev/
 build-metal/
 build-metal-noblas/
 build-all/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,23 @@ option(SA3_VULKAN "Build the GGML Vulkan backend"      OFF)
 option(SA3_METAL  "Build the GGML Metal backend"       OFF)
 option(SA3_HIP    "Build the GGML HIP/ROCm backend"    OFF)
 
+# iOS (and any host that only wants the library) has no use for the CLI tools -- they are
+# executables with argv and stdout, and an app bundle cannot run them anyway. Default it off when
+# cross-compiling to iOS so a library build does not fail on tools it was never going to ship.
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    set(SA3_BUILD_TOOLS_DEFAULT OFF)
+else()
+    set(SA3_BUILD_TOOLS_DEFAULT ON)
+endif()
+option(SA3_BUILD_TOOLS "Build the CLI tools and tests" ${SA3_BUILD_TOOLS_DEFAULT})
+option(SA3_STATIC "Build libsa3 as a static library (for embedding in an app binary)" OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    # An iOS app links a static archive or an embedded framework; a bare .dylib is not signable
+    # on its own. Static keeps the whole thing inside the app binary.
+    set(SA3_STATIC ON CACHE BOOL "" FORCE)
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+endif()
+
 if(SA3_CUDA)
     set(GGML_CUDA ON CACHE BOOL "" FORCE)
     # CUDA graphs need Ampere+ (CC >= 8.0). On older cards a stale GGML_CUDA_GRAPHS=ON
@@ -118,6 +135,7 @@ target_include_directories(sa3 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(sa3 INTERFACE ggml)
 
 # --- tools -----------------------------------------------------------------
+if(SA3_BUILD_TOOLS)
 add_executable(sa3-smoke tools/sa3-smoke.cpp)
 target_link_libraries(sa3-smoke PRIVATE sa3)
 
@@ -266,13 +284,21 @@ if(BUILD_TESTING)
         PROPERTIES LABELS "non-gpu;training;lora")
 endif()
 
-# --- libsa3: C ABI shared library (embed sa3 in a host app; see src/libsa3.h) ---------------
+endif() # SA3_BUILD_TOOLS
+
+# --- libsa3: C ABI library (embed sa3 in a host app; see src/libsa3.h) ---------------------
 # Windows: sa3.dll + sa3.lib (import lib).  Unix/macOS: libsa3.so / libsa3.dylib.
-add_library(sa3_shared SHARED src/libsa3.cpp vendor/yyjson/yyjson.c)
+# SA3_STATIC (forced on for iOS) builds libsa3.a instead, to link straight into an app binary.
+if(SA3_STATIC)
+    add_library(sa3_shared STATIC src/libsa3.cpp vendor/yyjson/yyjson.c)
+else()
+    add_library(sa3_shared SHARED src/libsa3.cpp vendor/yyjson/yyjson.c)
+endif()
 set_target_properties(sa3_shared PROPERTIES OUTPUT_NAME sa3)
 target_link_libraries(sa3_shared PRIVATE sa3)
 target_include_directories(sa3_shared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/vendor/yyjson)
 
+if(SA3_BUILD_TOOLS)
 # Pure-C smoke test / usage example; links the import lib (proves the C ABI + boundary).
 add_executable(sa3-libtest tools/sa3-libtest.c)
 target_include_directories(sa3-libtest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -287,3 +313,4 @@ target_link_libraries(sa3-libtrain PRIVATE sa3_shared)
 add_executable(sa3-libcancel tools/sa3-libcancel.c)
 target_include_directories(sa3-libcancel PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(sa3-libcancel PRIVATE sa3_shared)
+endif() # SA3_BUILD_TOOLS

--- a/src/train_job.h
+++ b/src/train_job.h
@@ -185,6 +185,22 @@ inline bool train_job_load_pairs(const TrainConfig& cfg, const std::string& spli
     return true;
 }
 
+// Does this backend actually support the LoRA backward pass? The Metal out_prod kernels stage
+// their tiles through simdgroup matrices with no scalar fallback, so a GPU below Apple7 (A13 and
+// older, and the iOS simulator, which reports Apple2) cannot run them. sa3 computes graphs on one
+// backend directly rather than through ggml_backend_sched, so nothing reroutes an unsupported op to
+// the CPU -- it would dispatch and trap. Ask before training instead of finding out mid-step.
+inline bool train_backend_supports_backward(ggml_backend_t backend) {
+    struct ggml_init_params ip = { 16*1024, nullptr, /*no_alloc=*/true };
+    ggml_context* ctx = ggml_init(ip);
+    if (!ctx) return true;   // cannot probe; let the run proceed rather than block on the probe
+    ggml_tensor* a = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 64, 32);
+    ggml_tensor* b = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 48, 32);
+    const bool ok = ggml_backend_supports_op(backend, ggml_out_prod(ctx, a, b));
+    ggml_free(ctx);
+    return ok;
+}
+
 // Run a training job to completion. `cfg` must already have been through train_finalize_defaults().
 // Returns false with `err` set on any failure; no exception escapes.
 inline bool run_training(const TrainConfig& cfg, const TrainHooks& hooks,
@@ -340,6 +356,14 @@ inline bool run_training(const TrainConfig& cfg, const TrainHooks& hooks,
 
         ggml_backend_t backend = sa3::make_backend(cfg.cpu_threads,
                                                    cfg.device.empty() ? nullptr : cfg.device.c_str());
+        if (!train_backend_supports_backward(backend)) {
+            const std::string name = ggml_backend_name(backend) ? ggml_backend_name(backend) : "(unknown)";
+            ggml_backend_free(backend);
+            err = "backend '" + name + "' cannot run the LoRA backward pass (OUT_PROD): its GPU is "
+                  "below Apple7 / lacks simdgroup matrix support. Train with --device cpu, or use a "
+                  "device with an A14 or newer GPU. Inference is unaffected";
+            return false;
+        }
         sa3::Tokenizer tok = sa3::Tokenizer::load(paths.tok.c_str());
         sa3::GgufModel te = sa3::load_gguf(paths.t5.c_str(), backend);
         sa3::GgufModel dit = sa3::load_gguf(paths.dit.c_str(), backend);


### PR DESCRIPTION
`CMAKE_SYSTEM_NAME=iOS` builds `libsa3.a` with Metal and no CLI tools. Device (arm64),
simulator (arm64), and x86_64 simulator all build with no source changes — ggml's Metal
backend is already iOS-aware.

Also bumps ggml for a Metal fix. Both out_prod kernels use `simdgroup_float8x8` with no
scalar fallback, but the op reported itself supported and then trapped on dispatch — seen
on the iOS simulator (`MTLGPUFamilyApple2`), and A13 and older devices are in the same
position. ggml now declines it; sa3 probes once at startup and fails naming `--device cpu`,
because we compute on a backend directly rather than through `ggml_backend_sched`, so
nothing would reroute the op to CPU.

No-op on Apple7+ (M-series, A14+): the 15-step small-music adapter is byte-identical.

The ggml commit touches only `ggml-metal-device.m`, which `ggml_add_backend(METAL)` does not
compile unless `GGML_METAL` is set — so CUDA/Vulkan builds are unaffected by construction.

App harness lives in a separate repo: betweentwomidnights/sa3.cpp-ios