### PR TITLE
train: persist pre-encoded latents so --latents-dir can consume our own output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,10 @@ target_link_libraries(sa3-model-paths-ae-test PRIVATE sa3)
 add_executable(sa3-lora-quant-merge-test tests/lora_quant_merge_test.cpp)
 target_link_libraries(sa3-lora-quant-merge-test PRIVATE sa3)
 
+add_executable(sa3-latents-cache-test tests/latents_cache_test.cpp vendor/yyjson/yyjson.c)
+target_link_libraries(sa3-latents-cache-test PRIVATE sa3)
+target_include_directories(sa3-latents-cache-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/vendor/yyjson)
+
 add_executable(sa3-set-wide-row-test tests/set_wide_row_test.cpp)
 target_link_libraries(sa3-set-wide-row-test PRIVATE sa3)
 
@@ -276,6 +280,7 @@ if(BUILD_TESTING)
     add_test(NAME sa3-lora-compose-test COMMAND sa3-lora-compose-test)
     add_test(NAME sa3-model-paths-ae-test COMMAND sa3-model-paths-ae-test)
     add_test(NAME sa3-lora-quant-merge-test COMMAND sa3-lora-quant-merge-test)
+    add_test(NAME sa3-latents-cache-test COMMAND sa3-latents-cache-test)
     add_test(NAME sa3-set-wide-row-test COMMAND sa3-set-wide-row-test)
     if(Python3_Interpreter_FOUND)
         add_test(NAME sa3-model-artifacts-test
@@ -288,7 +293,7 @@ if(BUILD_TESTING)
         sa3-train-diffusion-test sa3-train-lora-test sa3-train-dit-compile-test
         sa3-train-optimizer-test sa3-train-loop-compile-test sa3-train-checkpoint-test
         sa3-train-prompt-test sa3-train-inpaint-test
-        sa3-dit-lin-functional-test
+        sa3-dit-lin-functional-test sa3-latents-cache-test
         PROPERTIES LABELS "non-gpu;training;lora")
 endif()
 

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -27,6 +27,7 @@ sa3-train --dataset /path/to/dataset --steps 2000 \
 | `--duration SEC` | — | seconds of audio per training crop. Without it you get `--frames 512`, which is **47.6 s**. |
 | `--lora-scope full\|core` | `full` | `core` adapts only the 24 blocks' own projections (168 weights instead of 228): ~10% faster steps and ~11% smaller adapters, and in a matched 2000-step run the loss curve was within 0.0013 of `full` throughout. |
 | `--t5-encoding ENC` | auto | text-encoder precision, resolved apart from `--encoding`. Auto prefers `F16`, which is equivalent to `F32` at half the size (1074 → 537 MiB) and takes small-music's training peak from 2.28 to 1.78 GiB. `q8_0` saves another 0.26 GiB for a small, audible-on-paper cost. **Pick it for memory, never for speed:** encoding the caption is `t5_cond` in `SA3_TRAIN_PROFILE=1`, and on CUDA/medium that is **9 ms of a 1070 ms step — 0.84%** — so `q8_0` moves the step by −1 ms, within noise of `f16` (see below). |
+| `--latents-cache BOOL` | `true` | keep the pre-encode output and reuse it next run. Latents depend on the autoencoder and `--target-latent-rms` and on nothing the DiT or the adapter does, so a sweep over rank / lr / frames / steps / seed hits the cache every time. On the 10-track ratatat set a second run starts in **12 s instead of 285 s**, with bit-identical losses. Written to `<dataset>/latents/<variant>-<ae encoding>[-rms<target>]/`, or `--latents-cache-dir DIR` for a host whose dataset directory is read-only. A cache that cannot be written is reported once and the run continues. |
 | `--evict-text-encoder BOOL` | `false` | drop the text encoder between batches of captions instead of holding it for the whole run. It encodes a window of upcoming captions in one pass (63 of them, 47.6 MiB) and frees T5 until that window runs out, giving back **285 MiB at `q8_0`** for one encoder reload per window. The same reasoning as `--t5-encoding` taken to its conclusion: T5 is under 2% of a step but 15-19% of resident memory, so on a memory-bound host it is the first thing that should leave. **Quantizing past `q8_0` is not the alternative** — `q4_k_m` saves 79 MiB and was measured to cost audible quality. Needs pre-encoded latents (the default) and is silently inert without them. Off by default: a desktop has no reason to pay the reload. |
 | `--encoding ENC` | `f16` | base precision. Quantized bases (`q4_k_m`, `q8_0`, …) train on every backend and are both smaller and faster — on an M4 a `q4_k_m` medium base ran 2.77 s/step against 3.28 s/step for f16, on 962 MiB instead of 2773 MiB. |
 
@@ -37,6 +38,23 @@ Two things that are easy to miss:
   both are given. Shorter crops train faster and use less memory; the reference regime is ~47 s.
 - **MP3 datasets need `ffmpeg` on `PATH`.** Decoding shells out to it (see [Dataset](#dataset)).
   WAV already at 44.1 kHz does not — it is read natively.
+
+### Reusing latents
+
+The cache is written in the same `.npy` + `.json` convention `--latents-dir` reads, so it goes
+both ways: a directory this wrote can be handed to `--latents-dir`, and a pre-encode from
+gary4local, underfit, or the official PyTorch trainer can be trained on directly. The arrays are
+`[latent, frames]` C-order float32 with a `padding_mask` in the sidecar.
+
+The two flags are not interchangeable, and the difference is the point:
+
+- `--latents-dir` is **explicit**: it trains on exactly what you point it at, no questions asked.
+  That is what a parity run against a PyTorch reference needs.
+- `--latents-cache` is **checked**: an entry is only reused when the autoencoder, the loudness
+  target, and a fingerprint of the decoded audio all still agree. Anything else re-encodes.
+
+So a foreign pre-encode never satisfies a cache lookup by accident — it has no key in its sidecar
+and is skipped. Feeding one to the trainer is something you ask for by name.
 
 Training prints what it is actually doing at startup, which is worth a glance before walking away:
 

--- a/src/libsa3.cpp
+++ b/src/libsa3.cpp
@@ -240,10 +240,10 @@ SA3_API int sa3_train(const sa3_train_config* cfg, const sa3_train_hooks* hooks,
         sa3::TrainConfig tc;
         if (const char* models = std::getenv("SA3_MODELS_DIR"); models && *models) tc.models_dir = models;
 
-        // config_json first, so the explicit fields below win over it.
-        if (cfg->config_json && *cfg->config_json) {
+        // the config file first, so the explicit fields below win over it
+        if (cfg->config_path && *cfg->config_path) {
             std::string jerr;
-            if (!sa3::train_apply_json_config(tc, cfg->config_json, jerr)) { set_err(err, err_len, jerr); return 2; }
+            if (!sa3::train_apply_json_config(tc, cfg->config_path, jerr)) { set_err(err, err_len, jerr); return 2; }
         }
 
         auto str = [](const char* v, std::string& dst) { if (v && *v) dst = v; };
@@ -255,10 +255,11 @@ SA3_API int sa3_train(const sa3_train_config* cfg, const sa3_train_hooks* hooks,
         str(cfg->dataset_dir,    tc.dataset_dir);
         str(cfg->output_dir,     tc.output_dir);
         str(cfg->latents_dir,    tc.latents_dir);
-        str(cfg->prompt_config,  tc.prompt_config_path);
+        str(cfg->prompt_config_path, tc.prompt_config_path);
         str(cfg->resume_path,    tc.resume_path);
         str(cfg->adapter_type,   tc.adapter_type);
         str(cfg->lora_scope,     tc.lora_scope);
+        str(cfg->latents_cache_dir, tc.latents_cache_dir);
 
         if (cfg->steps > 0)            tc.max_steps = cfg->steps;
         if (cfg->rank > 0)             tc.rank = cfg->rank;
@@ -272,6 +273,7 @@ SA3_API int sa3_train(const sa3_train_config* cfg, const sa3_train_hooks* hooks,
         if (cfg->cpu_threads > 0)      tc.cpu_threads = cfg->cpu_threads;
         if (cfg->pre_encode)           tc.pre_encode = true;
         if (cfg->evict_text_encoder)   tc.evict_text_encoder = true;
+        if (cfg->latents_cache < 0)    tc.latents_cache = false;
         if (cfg->seed != 0)            tc.seed = (unsigned long long)cfg->seed;
 
         if (tc.dataset_dir.empty()) { set_err(err, err_len, "dataset_dir is required"); return 2; }

--- a/src/libsa3.h
+++ b/src/libsa3.h
@@ -230,8 +230,8 @@ SA3_API int sa3_convert_lora(const char* safetensors_path, const char* json_path
  */
 
 /* Zero-initialize, then set what you need; 0/NULL means the CLI default shown.
- * Anything not exposed here can be set through config_json, which is applied FIRST and then
- * overridden by whichever fields below are non-zero. */
+ * Anything not exposed here can be set through config_path -- a JSON file of any train config
+ * key, applied FIRST and then overridden by whichever fields below are non-zero. */
 typedef struct {
     const char* models_dir;      /* NULL -> $SA3_MODELS_DIR, else "models" */
     const char* variant;         /* NULL -> "medium" ("medium" | "small-music" | "small-sfx") */
@@ -239,11 +239,12 @@ typedef struct {
     const char* dataset_dir;     /* REQUIRED */
     const char* output_dir;      /* NULL -> train-runs/<dataset name> */
     const char* latents_dir;     /* optional pre-encoded latents; skips audio decode entirely */
-    const char* prompt_config;   /* optional dataset.json for prompt tag-composition */
+    const char* prompt_config_path; /* optional path to a dataset.json for prompt tag-composition */
     const char* resume_path;     /* optional adapter-step-N.gguf or trainer-state-step-N.gguf */
     const char* adapter_type;    /* NULL -> "dora-rows" */
     const char* lora_scope;      /* NULL -> "full" ("full" | "core") */
-    const char* config_json;     /* optional JSON of any train config key, applied before the above */
+    const char* config_path;     /* optional PATH to a JSON file of any train config key (the CLI's
+                                  * --config), applied before the above. Not JSON itself. */
     const char* device;          /* NULL/"" -> SA3_DEVICE then GPU-if-available; "cpu" forces CPU */
 
     int     steps;               /* 0 -> 10000 total optimizer updates */
@@ -276,6 +277,14 @@ typedef struct {
      * (or latents_dir); ignored otherwise. Meant for memory-bound hosts -- a phone training
      * medium -- and off by default everywhere else. Appended for the reason given above. */
     int     evict_text_encoder;
+    /* Reuse pre-encoded latents across runs. 0 -> on, the CLI default; negative disables, the same
+     * convention checkpoint_every uses, so a zero-initialized config keeps the default either way.
+     * Appended for the reason given above. */
+    int         latents_cache;
+    /* Where those latents live. NULL -> <dataset_dir>/latents/<variant>-<ae encoding>[-rms<target>].
+     * Set it to somewhere writable when dataset_dir is not: a host that cannot write the default
+     * still trains, but re-encodes the corpus on every run. Appended, as above. */
+    const char* latents_cache_dir;
 } sa3_train_config;
 
 /* One optimizer update. Pointers are valid only for the duration of the callback. */

--- a/src/train_config.h
+++ b/src/train_config.h
@@ -354,6 +354,7 @@ inline bool train_set_config_value(TrainConfig& c, const std::string& key, const
     return true;
 }
 
+// `path` is a JSON FILE, not JSON text -- the CLI spells this --config, the C ABI config_path.
 inline bool train_apply_json_config(TrainConfig& c, const std::string& path, std::string& err) {
     const std::string js = train_read_file(path, err);
     if (!err.empty()) return false;
@@ -561,6 +562,7 @@ inline std::string train_config_usage(const char* argv0) {
        << "              --t5-encoding ENC (text encoder precision; default auto, prefers F16)\n"
        << "              --ae-encoding ENC (autoencoder precision; default auto, prefers F32)\n"
        << "              --device cpu|<gpu> (default: SA3_DEVICE, else GPU if available)\n"
+       << "              --config FILE.json (a JSON file of any option below; flags override it)\n"
        << "adapter: --adapter-type lora|dora-rows|dora-cols|bora|*-xs --rank N --alpha F (default: = rank)\n"
        << "          --lora-scope full|core (full=228 weights, core=168 per-block projections)\n"
        << "          --lora-include a,b --lora-exclude a,b (substring filters, applied after scope)\n"

--- a/src/train_config.h
+++ b/src/train_config.h
@@ -98,6 +98,11 @@ struct TrainConfig {
     // Per-track latent-RMS loudness fix during native pre-encode (pre_encode.py
     // --per-track-target-latent-rms). 0 = off. The ratatat reference runs used 0.9.
     float target_latent_rms = 0.0f;
+    // Persist native pre-encode output so a later run reuses it instead of re-encoding. Latents
+    // depend on the autoencoder and target_latent_rms only, so a sweep over rank/lr/frames/steps/
+    // seed hits the cache every time. Empty cache_dir => <dataset>/latents/<variant>-<ae enc>/.
+    bool latents_cache = true;
+    std::string latents_cache_dir;
     // Drop the text encoder between batches of captions. T5 is 8-18 ms of a ~700 ms medium step
     // but holds 285 MB (Q8_0) for the entire run, so on a memory-bound device it is the worst
     // resident-bytes-per-step-second in the loop. Needs pre-encoded latents, because it works by
@@ -332,6 +337,10 @@ inline bool train_set_config_value(TrainConfig& c, const std::string& key, const
     else if (key == "latents-dir" || key == "latents_dir") c.latents_dir = value;
     else if (key == "target-latent-rms" || key == "target_latent_rms" || key == "per-track-target-latent-rms")
         return set_f(c.target_latent_rms);
+    else if (key == "latents-cache" || key == "latents_cache") {
+        if (!train_parse_bool(value, c.latents_cache)) { err = "invalid boolean for --" + key + ": " + value; return false; }
+    }
+    else if (key == "latents-cache-dir" || key == "latents_cache_dir") c.latents_cache_dir = value;
     else if (key == "evict-text-encoder" || key == "evict_text_encoder") {
         if (!train_parse_bool(value, c.evict_text_encoder)) { err = "invalid boolean for --" + key + ": " + value; return false; }
     }
@@ -566,6 +575,8 @@ inline std::string train_config_usage(const char* argv0) {
        << "memory: --checkpoint-backward BOOL (default true; per-block backward, fits VRAM)\n"
        << "latents: --pre-encode BOOL (default true; encode files once, crop in latent space)\n"
        << "          --latents-dir DIR (train on a gary4local pre-encode output; overrides --pre-encode)\n"
+       << "          --latents-cache BOOL (default true; keep pre-encode output and reuse it next run)\n"
+       << "          --latents-cache-dir DIR (default <dataset>/latents/<variant>-<ae encoding>)\n"
        << "          --target-latent-rms F (loudness fix during native pre-encode; ratatat runs used 0.9)\n"
        << "memory: --evict-text-encoder BOOL (default false; drop T5 between caption batches,\n"
        << "          ~285 MB back at Q8_0, one reload per window; needs pre-encoded latents)\n";

--- a/src/train_job.h
+++ b/src/train_job.h
@@ -35,6 +35,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <iomanip>
 #include <limits>
 #include <random>
 #include <sstream>
@@ -176,6 +177,21 @@ inline std::string train_job_build_prompt(const PromptConfig& pcfg, const TrainA
     return prompt_compose(pcfg, md, prompt_rng);
 }
 
+// Cache identity for one pre-encode. Keyed on the DECODED audio rather than the source file:
+// that is what the encoder actually consumes, so it is identical whether the audio arrived from
+// the filesystem or from a host's load_audio hook, and it also catches a decoder that starts
+// producing different samples for the same file.
+inline std::string train_job_latent_fingerprint(const TrainAudio& audio) {
+    uint64_t h = UINT64_C(14695981039346656037);
+    h = train_resume_fnv1a(h, &audio.sample_rate, sizeof(audio.sample_rate));
+    h = train_resume_fnv1a(h, &audio.n_channels, sizeof(audio.n_channels));
+    h = train_resume_fnv1a(h, &audio.n_samples, sizeof(audio.n_samples));
+    h = train_resume_fnv1a(h, audio.samples.data(), audio.samples.size() * sizeof(float));
+    std::ostringstream out;
+    out << std::hex << std::setw(16) << std::setfill('0') << h;
+    return out.str();
+}
+
 inline bool train_job_load_pairs(const TrainConfig& cfg, const std::string& split,
                                  TrainSplitManifest& manifest,
                                  std::vector<TrainAudioCaptionPair>& pairs, std::string& err) {
@@ -294,6 +310,7 @@ inline bool run_training(const TrainConfig& cfg, const TrainHooks& hooks,
             snap << "pre_encode=" << (cfg.pre_encode ? "true" : "false") << "\n";
             snap << "latents_dir=" << (cfg.latents_dir.empty() ? "(none)" : cfg.latents_dir) << "\n";
             snap << "evict_text_encoder=" << (cfg.evict_text_encoder ? "true" : "false") << "\n";
+            snap << "latents_cache=" << (cfg.latents_cache ? "true" : "false") << "\n";
             snap << "target_latent_rms=" << cfg.target_latent_rms << "\n";
             snap << "rank=" << cfg.rank << "\n";
             snap << "lora_scope=" << cfg.lora_scope << "\n";
@@ -513,6 +530,30 @@ inline bool run_training(const TrainConfig& cfg, const TrainHooks& hooks,
                 train_job_logf(hooks, "[pre-encode] loaded %zu latent files from %s\n",
                              lat_cache.size(), cfg.latents_dir.c_str());
             } else {
+                // Where a reusable pre-encode lands. Latents depend on the autoencoder and the
+                // loudness target and nothing else, so a sweep over rank/lr/frames/steps/seed
+                // reuses them. A host without a writable dataset dir passes its own path.
+                std::string cache_dir;
+                if (cfg.latents_cache) {
+                    const std::string ae_file = std::filesystem::path(paths.same).stem().string();
+                    const size_t dash = ae_file.rfind('-');
+                    const std::string ae_enc =
+                        dash == std::string::npos ? "unknown" : ae_file.substr(dash + 1);
+                    // Every dimension that invalidates gets its own directory, so switching one
+                    // does not evict the other's work: the key in the sidecar is the guard, the
+                    // layout is what keeps two valid caches from overwriting each other.
+                    std::string leaf = cfg.model_variant + "-" + ae_enc;
+                    if (cfg.target_latent_rms > 0.0f)
+                        leaf += "-rms" + train_job_format("%g", (double)cfg.target_latent_rms);
+                    cache_dir = cfg.latents_cache_dir.empty()
+                        ? (std::filesystem::path(cfg.dataset_dir) / "latents" / leaf).string()
+                        : cfg.latents_cache_dir;
+                }
+                sa3::TrainLatentKey cache_key;
+                cache_key.autoencoder = std::filesystem::path(paths.same).filename().string();
+                cache_key.target_latent_rms = cfg.target_latent_rms;
+                int cache_hits = 0, cache_writes = 0;
+                bool cache_write_failed = false;
                 for (const auto& pair : train_pairs) {
                     // Checked per FILE, because that is the granularity available: one iteration
                     // decodes a whole track and encodes it full-length, which on a phone is
@@ -530,13 +571,41 @@ inline bool run_training(const TrainConfig& cfg, const TrainHooks& hooks,
                     sa3::TrainAudio decoded;
                     if (!train_job_load_audio(hooks, pair, 44100, sc.out_channels / sc.patch_size, decoded, err))
                         throw std::runtime_error(err);
+                    // Decoding is what a hit still costs; it runs ~1-2% of the encode it skips.
+                    std::string cache_name;
                     sa3::TrainLatentEntry e;
+                    if (!cache_dir.empty()) {
+                        cache_name = sa3::train_latent_cache_name(stem);
+                        cache_key.source_fingerprint = train_job_latent_fingerprint(decoded);
+                        if (sa3::train_read_latent_entry(cache_dir, cache_name, sc.latent,
+                                                         cache_key, e)) {
+                            cache_hits++;
+                            train_job_logf(hooks, "[pre-encode] %s: reused %d frames\n",
+                                           stem.c_str(), e.n_valid);
+                            lat_cache[stem] = std::move(e);
+                            continue;
+                        }
+                    }
                     if (!sa3::train_pre_encode_file(ae, sc, decoded, cfg.target_latent_rms, e, err))
                         throw std::runtime_error(err);
                     train_job_logf(hooks, "[pre-encode] %s: %.1fs -> %d frames, gain %.4f, rms %.4f -> %.4f (%d rounds)\n",
                                  stem.c_str(), e.seconds_total, e.n_valid, e.gain, e.rms_pre, e.rms_achieved, e.norm_rounds);
+                    if (!cache_name.empty()) {
+                        // A cache that cannot be written is not a failed run: say so once and
+                        // carry on encoding, which is what would have happened anyway.
+                        std::string w_err;
+                        if (sa3::train_write_latent_entry(cache_dir, cache_name, e, cache_key, w_err)) {
+                            cache_writes++;
+                        } else if (!cache_write_failed) {
+                            cache_write_failed = true;
+                            train_job_logf(hooks, "[pre-encode] not caching (%s)\n", w_err.c_str());
+                        }
+                    }
                     lat_cache[stem] = std::move(e);
                 }
+                if (!cache_dir.empty() && (cache_hits || cache_writes))
+                    train_job_logf(hooks, "[pre-encode] cache: %d reused, %d written -> %s\n",
+                                   cache_hits, cache_writes, cache_dir.c_str());
             }
             for (const auto& pair : train_pairs) {
                 const std::string stem = std::filesystem::path(pair.audio_path).stem().string();

--- a/src/train_latents.h
+++ b/src/train_latents.h
@@ -281,7 +281,7 @@ inline bool train_write_latent_entry(const std::string& dir, const std::string& 
           << ",\n  \"target_latent_rms\": " << key.target_latent_rms
           << ",\n  \"seconds_total\": " << e.seconds_total
           << ",\n  \"audio_gain_applied\": " << e.gain
-          << ",\n  \"latent_rms_pre\": " << e.rms_pre
+          << ",\n  \"latent_rms_pre_norm\": " << e.rms_pre
           << ",\n  \"latent_rms_achieved\": " << e.rms_achieved
           << ",\n  \"norm_rounds\": " << e.norm_rounds
           << ",\n  \"padding_mask\": [";
@@ -330,7 +330,7 @@ inline bool train_read_latent_entry(const std::string& dir, const std::string& n
         v = yyjson_obj_get(root, "seconds_total");
         e.seconds_total = v ? yyjson_get_num(v) : 0.0;
         if ((v = yyjson_obj_get(root, "audio_gain_applied"))) e.gain = (float)yyjson_get_num(v);
-        if ((v = yyjson_obj_get(root, "latent_rms_pre"))) e.rms_pre = (float)yyjson_get_num(v);
+        if ((v = yyjson_obj_get(root, "latent_rms_pre_norm"))) e.rms_pre = (float)yyjson_get_num(v);
         if ((v = yyjson_obj_get(root, "latent_rms_achieved"))) e.rms_achieved = (float)yyjson_get_num(v);
         if ((v = yyjson_obj_get(root, "norm_rounds"))) e.norm_rounds = (int)yyjson_get_int(v);
     }

--- a/src/train_latents.h
+++ b/src/train_latents.h
@@ -44,6 +44,7 @@
 #include <filesystem>
 #include <fstream>
 #include <map>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -205,6 +206,150 @@ inline bool train_load_npy_f32_2d(const std::string& path, int64_t& d0, int64_t&
     data.resize((size_t)a * (size_t)b);
     f.read((char*)data.data(), (std::streamsize)(data.size() * sizeof(float)));
     if (!f) { err = "truncated .npy data: " + path; return false; }
+    return true;
+}
+
+// npy v1.0, little-endian f32, C-order 2D. Pairs with train_load_npy_f32_2d.
+inline bool train_write_npy_f32_2d(const std::string& path, int64_t d0, int64_t d1,
+                                   const float* data, std::string& err) {
+    std::ostringstream dict;
+    dict << "{'descr': '<f4', 'fortran_order': False, 'shape': (" << d0 << ", " << d1 << "), }";
+    std::string hdr = dict.str();
+    while ((10 + hdr.size() + 1) % 64 != 0) hdr.push_back(' ');   // align the data that follows
+    hdr.push_back('\n');
+
+    std::ofstream f(path, std::ios::binary);
+    if (!f) { err = "cannot write " + path; return false; }
+    const uint16_t hlen = (uint16_t)hdr.size();
+    f.write("\x93NUMPY\x01\x00", 8);
+    f.write((const char*)&hlen, 2);
+    f.write(hdr.data(), (std::streamsize)hdr.size());
+    f.write((const char*)data, (std::streamsize)((size_t)d0 * (size_t)d1 * sizeof(float)));
+    if (!f) { err = "failed while writing " + path; return false; }
+    return true;
+}
+
+// What a cached entry must agree with to be reused. Latents depend on the autoencoder and the
+// loudness target and on nothing the DiT or the adapter does, so a sweep over rank / lr / frames
+// / steps / seed reuses them. The autoencoder is also in the directory name, but it is repeated
+// here so an explicitly shared --latents-cache-dir cannot serve one autoencoder's latents for
+// another.
+struct TrainLatentKey {
+    int version = 1;
+    std::string autoencoder;          // resolved SAME gguf filename
+    std::string source_fingerprint;   // of the DECODED audio, see train_job_latent_fingerprint
+    float target_latent_rms = 0.0f;
+};
+
+// Filenames stay <stem>.npy / <stem>.json, matching gary4local, so a cache directory can be
+// handed to --latents-dir and a gary4local output can be dropped into a cache directory. The key
+// travels inside the sidecar instead of the name.
+inline std::string train_latent_cache_name(const std::string& stem) {
+    std::string safe = stem;
+    for (char& c : safe)
+        if (c == '/' || c == '\\' || c == ':' || c == '*' || c == '?' || c == '"' ||
+            c == '<' || c == '>' || c == '|') c = '_';
+    return safe;
+}
+
+// [latent, n_valid] as npy in gary4local's [C, T] C-order, plus a sidecar using its field names.
+// padding_mask is all ones because z is already trimmed to n_valid.
+inline bool train_write_latent_entry(const std::string& dir, const std::string& name,
+                                     const TrainLatentEntry& e, const TrainLatentKey& key,
+                                     std::string& err) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    if (ec) { err = "cannot create " + dir + ": " + ec.message(); return false; }
+
+    std::vector<float> ct((size_t)e.latent * (size_t)e.n_valid);
+    for (int t = 0; t < e.n_valid; ++t)
+        for (int c = 0; c < e.latent; ++c)
+            ct[(size_t)c * e.n_valid + t] = e.z[(size_t)t * e.latent + c];
+
+    const fs::path np = fs::path(dir) / (name + ".npy");
+    const fs::path jp = fs::path(dir) / (name + ".json");
+    const fs::path np_tmp = fs::path(dir) / (name + ".npy.part");
+    const fs::path jp_tmp = fs::path(dir) / (name + ".json.part");
+    if (!train_write_npy_f32_2d(np_tmp.string(), e.latent, e.n_valid, ct.data(), err)) return false;
+    {
+        std::ofstream j(jp_tmp);
+        if (!j) { err = "cannot write " + jp_tmp.string(); return false; }
+        j << "{\n  \"cache_version\": " << key.version
+          << ",\n  \"autoencoder\": \"" << key.autoencoder << "\""
+          << ",\n  \"source_fingerprint\": \"" << key.source_fingerprint << "\""
+          << ",\n  \"target_latent_rms\": " << key.target_latent_rms
+          << ",\n  \"seconds_total\": " << e.seconds_total
+          << ",\n  \"audio_gain_applied\": " << e.gain
+          << ",\n  \"latent_rms_pre\": " << e.rms_pre
+          << ",\n  \"latent_rms_achieved\": " << e.rms_achieved
+          << ",\n  \"norm_rounds\": " << e.norm_rounds
+          << ",\n  \"padding_mask\": [";
+        for (int i = 0; i < e.n_valid; ++i) j << (i ? "," : "") << "1";
+        j << "]\n}\n";
+        if (!j) { err = "failed while writing " + jp_tmp.string(); return false; }
+    }
+    // npy first: an interrupted write must never leave a sidecar naming a truncated array
+    fs::rename(np_tmp, np, ec);
+    if (ec) { err = "cannot place " + np.string() + ": " + ec.message(); return false; }
+    fs::rename(jp_tmp, jp, ec);
+    if (ec) { err = "cannot place " + jp.string() + ": " + ec.message(); return false; }
+    return true;
+}
+
+// False for any reason at all -- missing, unreadable, wrong width, key disagreement -- because
+// every one of them means "encode it again", which is correct and merely slow. A gary4local
+// sidecar has no key fields and so never matches, which is the intended answer: --latents-dir is
+// how you train on those, deliberately and by name.
+inline bool train_read_latent_entry(const std::string& dir, const std::string& name,
+                                    int expect_latent, const TrainLatentKey& want,
+                                    TrainLatentEntry& out) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    const fs::path np = fs::path(dir) / (name + ".npy");
+    const fs::path jp = fs::path(dir) / (name + ".json");
+    if (!fs::exists(np, ec) || !fs::exists(jp, ec)) return false;
+
+    std::ifstream jf(jp);
+    std::string js((std::istreambuf_iterator<char>(jf)), std::istreambuf_iterator<char>());
+    yyjson_doc* doc = yyjson_read(js.data(), js.size(), 0);
+    if (!doc) return false;
+    yyjson_val* root = yyjson_doc_get_root(doc);
+    auto str = [&](const char* k) {
+        yyjson_val* v = yyjson_obj_get(root, k);
+        return v && yyjson_is_str(v) ? std::string(yyjson_get_str(v)) : std::string();
+    };
+    yyjson_val* v = yyjson_obj_get(root, "cache_version");
+    const bool key_ok = v && (int)yyjson_get_int(v) == want.version &&
+                        str("autoencoder") == want.autoencoder &&
+                        str("source_fingerprint") == want.source_fingerprint &&
+                        (v = yyjson_obj_get(root, "target_latent_rms")) != nullptr &&
+                        (float)yyjson_get_num(v) == want.target_latent_rms;
+    TrainLatentEntry e;
+    if (key_ok) {
+        v = yyjson_obj_get(root, "seconds_total");
+        e.seconds_total = v ? yyjson_get_num(v) : 0.0;
+        if ((v = yyjson_obj_get(root, "audio_gain_applied"))) e.gain = (float)yyjson_get_num(v);
+        if ((v = yyjson_obj_get(root, "latent_rms_pre"))) e.rms_pre = (float)yyjson_get_num(v);
+        if ((v = yyjson_obj_get(root, "latent_rms_achieved"))) e.rms_achieved = (float)yyjson_get_num(v);
+        if ((v = yyjson_obj_get(root, "norm_rounds"))) e.norm_rounds = (int)yyjson_get_int(v);
+    }
+    yyjson_doc_free(doc);
+    if (!key_ok) return false;
+
+    int64_t C = 0, T = 0;
+    std::vector<float> raw;
+    std::string ignored;
+    if (!train_load_npy_f32_2d(np.string(), C, T, raw, ignored)) return false;
+    if (expect_latent > 0 && C != expect_latent) return false;
+
+    e.latent = (int)C;
+    e.n_valid = (int)T;
+    e.z.resize((size_t)C * (size_t)T);
+    for (int64_t t = 0; t < T; ++t)
+        for (int64_t c = 0; c < C; ++c)
+            e.z[(size_t)t * C + c] = raw[(size_t)c * T + t];
+    out = std::move(e);
     return true;
 }
 

--- a/tests/latents_cache_test.cpp
+++ b/tests/latents_cache_test.cpp
@@ -1,0 +1,162 @@
+// latents_cache_test: the pre-encode cache round-trips, and refuses to serve a stale entry.
+//
+// A false miss costs an encode. A false hit trains on the wrong latents and says nothing, so the
+// key checks below are the point of the test, not the round-trip.
+//
+// The npy is also asserted against the NumPy format spec rather than against our own reader,
+// because the format exists so that gary4local / underfit / the official PyTorch pre-encode can
+// read what we write and we can read what they write.
+#include "train_latents.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+static int fails = 0;
+
+static void expect(bool ok, const std::string& msg) {
+    if (!ok) {
+        std::printf("  FAIL %s\n", msg.c_str());
+        fails++;
+    }
+}
+
+static sa3::TrainLatentEntry make_entry(int latent, int frames) {
+    sa3::TrainLatentEntry e;
+    e.latent = latent;
+    e.n_valid = frames;
+    e.z.resize((size_t)latent * (size_t)frames);
+    for (int t = 0; t < frames; ++t)
+        for (int c = 0; c < latent; ++c)
+            e.z[(size_t)t * latent + c] = 0.001f * (float)(t * latent + c) - 0.5f;
+    e.seconds_total = 12.345;
+    e.gain = 0.5539f;
+    e.rms_pre = 1.2232f;
+    e.rms_achieved = 0.9248f;
+    e.norm_rounds = 4;
+    return e;
+}
+
+static sa3::TrainLatentKey make_key() {
+    sa3::TrainLatentKey k;
+    k.autoencoder = "stable-audio-3-medium-same-l-v1.0-Q4_K_M.gguf";
+    k.source_fingerprint = "0123456789abcdef";
+    k.target_latent_rms = 0.9f;
+    return k;
+}
+
+// The parts of the NumPy spec a foreign reader depends on.
+static void check_npy_spec(const fs::path& p, int64_t d0, int64_t d1) {
+    std::ifstream f(p, std::ios::binary);
+    expect((bool)f, "npy opens");
+    if (!f) return;
+    std::string all((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    expect(all.size() > 10, "npy is not truncated");
+    if (all.size() <= 10) return;
+
+    expect(std::memcmp(all.data(), "\x93NUMPY", 6) == 0, "npy magic");
+    expect((unsigned char)all[6] == 1 && (unsigned char)all[7] == 0, "npy version is 1.0");
+    uint16_t hlen = 0;
+    std::memcpy(&hlen, all.data() + 8, 2);
+    expect((10 + hlen) % 64 == 0, "npy header is 64-byte aligned");
+    const std::string hdr = all.substr(10, hlen);
+    expect(!hdr.empty() && hdr.back() == '\n', "npy header ends with a newline");
+    expect(hdr.find("'descr': '<f4'") != std::string::npos, "npy descr is <f4");
+    expect(hdr.find("'fortran_order': False") != std::string::npos, "npy is C-order");
+    const std::string shape = "'shape': (" + std::to_string(d0) + ", " + std::to_string(d1) + ")";
+    expect(hdr.find(shape) != std::string::npos, "npy shape is " + shape + " (channels first)");
+    expect(all.size() - 10 - hlen == (size_t)d0 * (size_t)d1 * sizeof(float),
+           "npy data length matches its shape");
+}
+
+int main() {
+    std::printf("latents_cache_test\n");
+    const fs::path dir = fs::temp_directory_path() / "sa3_latents_cache_test";
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+
+    const int latent = 8, frames = 37;
+    const sa3::TrainLatentEntry src = make_entry(latent, frames);
+    const sa3::TrainLatentKey key = make_key();
+    const std::string name = sa3::train_latent_cache_name("a track [with brackets]");
+    std::string err;
+
+    expect(sa3::train_write_latent_entry(dir.string(), name, src, key, err),
+           "write succeeds: " + err);
+    check_npy_spec(dir / (name + ".npy"), latent, frames);
+    expect(!fs::exists(dir / (name + ".npy.part")), "no .part left behind");
+
+    // round-trip: every value and every scalar the trainer reads back out
+    sa3::TrainLatentEntry got;
+    expect(sa3::train_read_latent_entry(dir.string(), name, latent, key, got), "matching key hits");
+    expect(got.latent == src.latent && got.n_valid == src.n_valid, "shape survives");
+    expect(got.z.size() == src.z.size(), "element count survives");
+    double worst = 0.0;
+    for (size_t i = 0; i < std::min(got.z.size(), src.z.size()); ++i)
+        worst = std::max(worst, (double)std::fabs(got.z[i] - src.z[i]));
+    expect(worst == 0.0, "latents are bit-identical, not merely close");
+    expect(got.seconds_total == src.seconds_total, "seconds_total survives");
+    expect(got.gain == src.gain && got.rms_pre == src.rms_pre &&
+           got.rms_achieved == src.rms_achieved && got.norm_rounds == src.norm_rounds,
+           "loudness-fix results survive");
+
+    // a filename is not a key: each of these must miss
+    sa3::TrainLatentEntry ignored;
+    sa3::TrainLatentKey k = key;
+    k.source_fingerprint = "ffffffffffffffff";
+    expect(!sa3::train_read_latent_entry(dir.string(), name, latent, k, ignored),
+           "different audio misses");
+    k = key;
+    k.target_latent_rms = 0.5f;
+    expect(!sa3::train_read_latent_entry(dir.string(), name, latent, k, ignored),
+           "different target_latent_rms misses");
+    k = key;
+    k.autoencoder = "stable-audio-3-medium-same-l-v1.0-Q8_0.gguf";
+    expect(!sa3::train_read_latent_entry(dir.string(), name, latent, k, ignored),
+           "different autoencoder misses");
+    k = key;
+    k.version = key.version + 1;
+    expect(!sa3::train_read_latent_entry(dir.string(), name, latent, k, ignored),
+           "different cache version misses");
+    expect(!sa3::train_read_latent_entry(dir.string(), name, latent + 1, key, ignored),
+           "different latent width misses");
+    expect(!sa3::train_read_latent_entry(dir.string(), "no such entry", latent, key, ignored),
+           "absent entry misses");
+
+    // train_load_latent_dir is how a gary4local/underfit output is consumed; a cache directory
+    // has to be readable by it too, or the format claim is empty
+    sa3::TrainLatentCache cache;
+    expect(sa3::train_load_latent_dir(dir.string(), latent, cache, err),
+           "the gary4local reader accepts a cache directory: " + err);
+    expect(cache.size() == 1, "one entry seen by the gary4local reader");
+    auto it = cache.find(name);
+    expect(it != cache.end(), "keyed by plain stem, no fingerprint suffix");
+    if (it != cache.end()) {
+        expect(it->second.n_valid == frames, "gary4local reader agrees on n_valid");
+        double w = 0.0;
+        for (size_t i = 0; i < std::min(it->second.z.size(), src.z.size()); ++i)
+            w = std::max(w, (double)std::fabs(it->second.z[i] - src.z[i]));
+        expect(w == 0.0, "gary4local reader recovers the same latents");
+    }
+
+    // a sidecar without key fields is a gary4local file, not a cache entry: it must not be served
+    // as one, or --latents-dir data would silently satisfy a cache lookup for different audio
+    {
+        std::ofstream j(dir / (name + ".json"));
+        j << "{\"seconds_total\": 12.345, \"padding_mask\": [";
+        for (int i = 0; i < frames; ++i) j << (i ? "," : "") << "1";
+        j << "]}\n";
+    }
+    expect(!sa3::train_read_latent_entry(dir.string(), name, latent, key, ignored),
+           "an unkeyed gary4local sidecar is not treated as a cache hit");
+
+    fs::remove_all(dir, ec);
+    std::printf(fails ? "FAILED (%d)\n" : "OK\n", fails);
+    return fails ? 1 : 0;
+}

--- a/tools/sa3-libtrain.c
+++ b/tools/sa3-libtrain.c
@@ -2,7 +2,11 @@
  * This is the call sequence an embedded host (iOS app, plugin) would use to train an adapter
  * in-process, including the callbacks it drives the run with.
  *
- *   usage: sa3-libtrain <dataset-dir> <out-dir> [steps] [variant] [latents-dir]
+ *   usage: sa3-libtrain <dataset-dir> <out-dir> [steps] [variant] [latents-dir] [latents-cache-dir]
+ *
+ * latents-cache-dir is the one a sandboxed host usually has to set: the pre-encode cache defaults
+ * to a directory under dataset_dir, which an app that cannot write there needs to redirect. Pass
+ * "-" to turn the cache off instead.
  *
  * The adapter it writes is byte-identical to one produced by `sa3-train` with the same config.
  */
@@ -38,7 +42,9 @@ static int should_cancel(void* user) {
 
 int main(int argc, char** argv) {
     if (argc < 3) {
-        fprintf(stderr, "usage: %s <dataset-dir> <out-dir> [steps] [variant] [latents-dir]\n", argv[0]);
+        fprintf(stderr,
+                "usage: %s <dataset-dir> <out-dir> [steps] [variant] [latents-dir] [latents-cache-dir]\n",
+                argv[0]);
         return 2;
     }
 
@@ -49,6 +55,10 @@ int main(int argc, char** argv) {
     cfg.steps            = argc > 3 ? atoi(argv[3]) : 4;
     cfg.variant          = argc > 4 ? argv[4] : "small-music";
     cfg.latents_dir      = argc > 5 ? argv[5] : NULL;
+    if (argc > 6) {
+        if (strcmp(argv[6], "-") == 0) cfg.latents_cache = -1;   /* negative disables, like checkpoint_every */
+        else                           cfg.latents_cache_dir = argv[6];
+    }
     cfg.frames           = 128;
     cfg.checkpoint_every = -1;              /* no intermediate checkpoints for a smoke test */
     cfg.seed             = 42;


### PR DESCRIPTION
Closes #35.

Native pre-encode now writes its latents and reuses them next run. On the 10-track ratatat set a
second run reaches step 1 in **12 s instead of 285 s**, with bit-identical losses. 27 MB of cache
for 42.6 min of audio.

Keyed on the **decoded audio**, not the source file, so it works the same whether audio comes from
the filesystem or from a host's `load_audio` hook — a file fingerprint would have served
workstations and skipped iOS, which is what the issue was filed for. Anything that invalidates
(variant, autoencoder encoding, `target_latent_rms`) gets its own directory; the key in the sidecar
is the guard. A cache that cannot be written is reported once and the run continues.

## Verified on the PC (CUDA)

Both directions, against the real gary4local/PyTorch stack rather than against our own reader:

- our `.npy` loads in numpy 2.4.6 — the interpreter `services/sa3/env` runs — with correct shape,
  dtype, order and values
- a genuine PyTorch pre-encode job (`billie-1788079527`) trains here through `--latents-dir`
- `PreEncodedDataset.__getitem__` hard-indexes only `padding_mask` and `seconds_total`; both are
  written, so our cache directories are directly trainable by the official dataset
- `n_valid` is identical to `_valid_latent_length`, not merely close

Fixed one real mismatch found this way: the reference spells the field `latent_rms_pre_norm`.

21/21 tests. `tests/latents_cache_test.cpp` covers the round-trip, the npy against the NumPy spec,
every invalidation case, and that a foreign sidecar never satisfies a cache lookup.

## Validated on Metal

- [x] M4
- [x] iPhone

## API naming, found during that validation

`config_json` took a **path** to a JSON file while both its name and its doc comment said content;
the CLI spells the same thing `--config`. It is `config_path` now. `prompt_config` was also a path
missing its suffix, next to a correctly-named `resume_path`, and maps to `prompt_config_path`
internally — renamed to match. Neither field moves or changes type, so the ABI is unchanged and an
already-compiled host keeps working; **source naming either field needs the new spelling.**

That audit also turned up two gaps: `latents_cache` / `latents_cache_dir` had never been exposed on
the C ABI at all, so the read-only-dataset case this feature exists for was only reachable through
`config_path`; and `--config` was parsed but absent from `--help`. Both fixed.

`latents_cache` follows `checkpoint_every`: 0 keeps the default, negative disables, so a
zero-initialized config still behaves.

## Validated after the rename

The iOS host was recompiled against the current header and re-checked on device; the naming
change improved things on the `sa3.cpp-ios` side too. `latents_cache_dir` and `latents_cache = -1`
are also exercised end-to-end through the C ABI by `sa3-libtrain`: a redirected cache writes to
the given directory and leaves `dataset_dir` untouched, a second run reuses it with an identical
loss, and the disable path encodes without reading or writing.
