### PR TITLE
libsa3: continuation source splicing, and a metadata channel to report it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,9 @@ add_executable(sa3-latents-cache-test tests/latents_cache_test.cpp vendor/yyjson
 target_link_libraries(sa3-latents-cache-test PRIVATE sa3)
 target_include_directories(sa3-latents-cache-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/vendor/yyjson)
 
+add_executable(sa3-continuation-splice-test tests/continuation_splice_test.cpp)
+target_link_libraries(sa3-continuation-splice-test PRIVATE sa3)
+
 add_executable(sa3-set-wide-row-test tests/set_wide_row_test.cpp)
 target_link_libraries(sa3-set-wide-row-test PRIVATE sa3)
 
@@ -299,6 +302,7 @@ if(BUILD_TESTING)
     add_test(NAME sa3-model-paths-ae-test COMMAND sa3-model-paths-ae-test)
     add_test(NAME sa3-lora-quant-merge-test COMMAND sa3-lora-quant-merge-test)
     add_test(NAME sa3-latents-cache-test COMMAND sa3-latents-cache-test)
+    add_test(NAME sa3-continuation-splice-test COMMAND sa3-continuation-splice-test)
     add_test(NAME sa3-set-wide-row-test COMMAND sa3-set-wide-row-test)
     if(SA3_BUILD_SAT)
         add_test(NAME sa3-sat-sampling-test COMMAND sa3-sat-sampling-test)
@@ -342,7 +346,7 @@ if(BUILD_TESTING)
         sa3-train-diffusion-test sa3-train-lora-test sa3-train-dit-compile-test
         sa3-train-optimizer-test sa3-train-loop-compile-test sa3-train-checkpoint-test
         sa3-train-prompt-test sa3-train-inpaint-test
-        sa3-dit-lin-functional-test sa3-latents-cache-test
+        sa3-dit-lin-functional-test sa3-latents-cache-test sa3-continuation-splice-test
         PROPERTIES LABELS "non-gpu;training;lora")
     if(SA3_BUILD_SAT)
         set_tests_properties(sa3-sat-sampling-test sa3-sat-cli-help-test

--- a/docs/CONTINUATION.md
+++ b/docs/CONTINUATION.md
@@ -1,0 +1,120 @@
+# continuation splice
+
+continuation feeds a clip back in, regenerates an inpaint window at the end of it, and decodes the
+result. everything before that window is *supposed* to survive untouched. it does not. the source
+makes a full round trip through the autoencoder on the way in and back out, so the region the model
+was told to keep still comes back carrying the codec's artefacts -- and since each continuation's
+output is the next one's input, they compound.
+
+the python sa3 service in
+[gary4local](https://github.com/betweentwomidnights/gary-localhost-installer) stopped fighting that
+and started pasting the original audio back over the head of the output. it is a large quality win
+and it takes a lot of pressure off decoder/encoder loras, which is why it lives here at the library
+layer rather than in one client.
+
+it is **on by default**, the same way peak normalization is: a zero-initialized request already gets
+gary4local's tuned loudness rather than raw output, and this is the same kind of default.
+
+## the two halves
+
+they are separable and the second is useless without the first.
+
+**1. mask overlap.** the inpaint window starts *before* the source ends, so the model regenerates
+the handoff instead of butting up against a hard boundary:
+
+```text
+max_overlap = max(0, source_duration - 0.05)      # always keep 50 ms of real source
+overlap     = min(max_overlap, max(0, requested)) # requested default 0.2 s
+mask_start  = max(0, source_duration - overlap)
+```
+
+**2. splice.** after decode, before any loudness shaping, restore the original source over
+`[0, mask_start)` and equal-power crossfade its last 30 ms into the model's audio. the deliberately
+regenerated overlap is never pasted over:
+
+```text
+splice_end = min(round(mask_start * sr), source_len, audio_len)
+xfade      = clamp(round(xfade_seconds * sr), 0, splice_end / 2)
+hard_end   = splice_end - xfade
+
+# optional RMS match, both measured over [0, splice_end)
+if gain_match and source_rms > 1e-6 and model_rms > 1e-6:
+    gain   = clamp(model_rms / source_rms, 0.25, 4.0)
+    source = source * gain
+
+out[0 : hard_end]          = source[0 : hard_end]
+out[hard_end : splice_end] = source * cos(phase) + audio * sin(phase)
+                             where phase = linspace(0, pi/2, xfade)
+# out[splice_end : ] is the model's audio, untouched
+```
+
+the gain is applied to the *source*, pulling the restored head up to the model's level -- not the
+other way round. loudness shaping then treats the whole thing as one signal, so the seam gets the
+same normalize and limiter as the audio on either side of it. that ordering is load-bearing.
+
+`xfade == 1` is degenerate -- a single point at phase 0 would be pure source, not a crossfade -- so
+the model's sample stands there. this matches the reference.
+
+## how mask_overlap meets inpaint_start
+
+the python service never sees an explicit mask start; it derives one from the source duration.
+libsa3's callers pass `inpaint_start` directly, so the two have to be reconciled.
+
+**with the splice on, `inpaint_start` means "where the source ends and the continuation should
+musically begin"**, and the library owns the mechanics from there: it pulls the sampler's window
+back by `mask_overlap` (clamped to leave at least 50 ms of real source) and splices up to that same
+pulled-back point. one number, computed once, used by both halves -- which is the property that
+makes the splice correct, since `splice_end` must equal the mask start the sampler actually used.
+
+this is what lets an existing caller get the improvement without changing its call: a client passing
+`inpaint_start = source duration` is already asking for exactly this. `mask_overlap = 0` disables
+the pullback for anyone who wants literally the window they asked for.
+
+this is the one place turning the splice on changes what an existing field means.
+
+### mid-clip inpainting
+
+the semantics above are continuation semantics, and the splice reads every inpaint request through
+them. for a window in the *middle* of a clip -- `--inpaint-start 2 --inpaint-end 4` on a ten second
+source -- that means two things: the window start moves earlier by `mask_overlap`, and the audio
+before it is restored from the source while the audio after `inpaint_end` is not. the restored head
+is strictly an improvement (that region was meant to be kept), but the window is not quite the one
+you asked for.
+
+if you are inpainting rather than continuing, pass `mask_overlap = 0` for exactly the window you
+asked for, or `splice = 0` (`--no-splice`) for the old behaviour outright.
+
+## knobs
+
+| field | env | default |
+| --- | --- | --- |
+| `splice` | `SA3_CONTINUE_SPLICE_SOURCE` | on |
+| `mask_overlap` | `SA3_CONTINUE_MASK_OVERLAP` | `0.2` s |
+| `xfade` | `SA3_CONTINUE_SPLICE_XFADE` | `0.03` s |
+| `gain_match` | `SA3_CONTINUE_SPLICE_GAIN_MATCH` | on |
+
+the env names are the ones gary4local already uses, so a knob learned there transfers verbatim.
+
+from C, `sa3_splice` on `sa3_request_ex` mirrors `sa3_loudness`: leave `set = 0` for the defaults
+plus any env overrides, or set `set = 1` to drive it per-request -- including the old un-spliced
+behaviour with `splice = 0`, exactly as a caller asks for raw audio today.
+
+from the CLI:
+
+```sh
+sa3-generate --model small-music --init take.wav --inpaint-start 12.0 --inpaint-end 18.0 \
+             --prompt "..." --out continued.wav
+sa3-generate ... --no-splice            # A/B against the old behaviour
+sa3-generate ... --mask-overlap 0.4 --splice-xfade 0.05 --no-splice-gain-match
+```
+
+## what it reports
+
+`sa3_last_meta()` fills `splice_applied`, `splice_end_seconds`, `splice_xfade_applied`,
+`splice_gain`, `mask_start_seconds` and `mask_overlap_applied` alongside the loudness measurements.
+the pipeline also prints both halves:
+
+```text
+continue: mask pulled back 0.200s to 11.800s (source 12.000s), splicing on decode
+continue splice: kept 0-11.800s, xfade 30ms, gain 1.043
+```

--- a/docs/CONTINUATION.md
+++ b/docs/CONTINUATION.md
@@ -95,9 +95,11 @@ asked for, or `splice = 0` (`--no-splice`) for the old behaviour outright.
 
 the env names are the ones gary4local already uses, so a knob learned there transfers verbatim.
 
-from C, `sa3_splice` on `sa3_request_ex` mirrors `sa3_loudness`: leave `set = 0` for the defaults
-plus any env overrides, or set `set = 1` to drive it per-request -- including the old un-spliced
-behaviour with `splice = 0`, exactly as a caller asks for raw audio today.
+from C, use the size-tagged `sa3_request_v2` and call `sa3_generate_v2`. its `sa3_splice` mirrors
+`sa3_loudness`: leave `set = 0` for the defaults plus any env overrides, or set `set = 1` to drive
+it per-request -- including the old un-spliced behaviour with `splice = 0`, exactly as a caller
+asks for raw audio today. the older `sa3_request_ex` remains byte-for-byte ABI compatible and uses
+the defaults/env overrides.
 
 from the CLI:
 

--- a/src/audio_post.h
+++ b/src/audio_post.h
@@ -251,4 +251,158 @@ inline void apply_audio_loudness(std::vector<float>& audio, const LoudnessParams
     }
 }
 
+
+// ---------------------------------------------------------------------------------------------
+// Continuation source splicing.
+//
+// Continuation regenerates an inpaint window over source audio that has made a full round trip
+// through the autoencoder, so the region the model was told to KEEP still comes back with the
+// encoder/decoder's artefacts — and every continuation compounds them. Pasting the original
+// samples back over that region removes the round trip from the kept audio entirely.
+//
+// Two halves, and the second is useless without the first: the mask is pulled back so the model
+// regenerates the handoff instead of butting against a hard boundary, and the source is then
+// restored up to that same pulled-back point. One number, computed once, used by both — which is
+// the property that makes the seam land where the crossfade expects it.
+//
+// Ported from gary4local's sa3 service (splice_continuation_source / continuation_mask_bounds),
+// including its degenerate cases, so a knob learned there transfers verbatim.
+
+// Real source always kept, so a continuation from a very short clip still conditions on something.
+inline constexpr float kMinContinuationSourceSeconds = 0.05f;
+
+struct SpliceParams {
+    bool  enabled      = true;
+    float mask_overlap = 0.2f;    // s of source the model regenerates before the mask start
+    float xfade        = 0.03f;   // s of equal-power crossfade at the seam
+    bool  gain_match   = true;    // RMS-match the restored head to the model's level
+};
+
+struct SpliceMeta {
+    bool  applied              = false;
+    float splice_end_seconds   = 0.0f;
+    float xfade_applied        = 0.0f;
+    float gain                 = 1.0f;
+    float mask_start_seconds   = 0.0f;   // what the sampler used, after the overlap pullback
+    float mask_overlap_applied = 0.0f;
+};
+
+inline bool env_bool(const char* name, bool fallback) {
+    const char* text = std::getenv(name);
+    if (!text) return fallback;
+    std::string s = lower_ascii_copy(text);
+    const size_t a = s.find_first_not_of(" \t\r\n");
+    const size_t b = s.find_last_not_of(" \t\r\n");
+    s = a == std::string::npos ? std::string() : s.substr(a, b - a + 1);
+    return !(s.empty() || s == "0" || s == "false" || s == "no" || s == "off");
+}
+
+inline SpliceParams splice_defaults_from_env() {
+    SpliceParams p;
+    p.enabled      = env_bool("SA3_CONTINUE_SPLICE_SOURCE", p.enabled);
+    p.mask_overlap = std::max(0.0f, env_float("SA3_CONTINUE_MASK_OVERLAP", p.mask_overlap));
+    p.xfade        = env_float("SA3_CONTINUE_SPLICE_XFADE", p.xfade);
+    p.gain_match   = env_bool("SA3_CONTINUE_SPLICE_GAIN_MATCH", p.gain_match);
+    return p;
+}
+
+inline bool validate_splice_params(const SpliceParams& p, std::string& err) {
+    if (!std::isfinite(p.mask_overlap) || p.mask_overlap < 0.0f) {
+        err = "mask_overlap must be finite and >= 0";
+        return false;
+    }
+    if (!std::isfinite(p.xfade) || p.xfade < 0.0f) {
+        err = "xfade must be finite and >= 0";
+        return false;
+    }
+    return true;
+}
+
+// Pull the mask start back into the source by `requested_overlap`, always leaving at least
+// kMinContinuationSourceSeconds of real source ahead of it.
+inline void continuation_mask_bounds(float source_duration, float requested_overlap,
+                                     float& out_overlap, float& out_mask_start) {
+    const float max_overlap = std::max(0.0f, source_duration - kMinContinuationSourceSeconds);
+    out_overlap = std::min(max_overlap, std::max(0.0f, requested_overlap));
+    out_mask_start = std::max(0.0f, source_duration - out_overlap);
+}
+
+// Restore `source` over [0, mask_start) of `audio`, equal-power crossfading into the model's audio
+// over the last `params.xfade` seconds. Both buffers are PLANAR; `source` carries its own stride so
+// a padded generation buffer can be spliced from directly, and its own channel count so a mono
+// source conforms the way the reference does (downmix, then repeat).
+//
+// Call BEFORE any loudness shaping: the seam then gets the same normalize and limiter as the audio
+// on either side of it, rather than a joint between two differently-shaped signals.
+inline void splice_continuation_source(std::vector<float>& audio, int audio_n, int n_ch,
+                                       const float* source, int source_n, int source_stride,
+                                       int source_n_ch, float mask_start_seconds, int sample_rate,
+                                       const SpliceParams& params, SpliceMeta& meta) {
+    meta.mask_start_seconds = mask_start_seconds;
+    if (!params.enabled || !source || source_n <= 0 || source_n_ch <= 0) return;
+    if (audio_n <= 0 || n_ch <= 0 || sample_rate <= 0 || mask_start_seconds <= 0.0f) return;
+    if (audio.size() < (size_t)audio_n * n_ch || source_stride < source_n) return;
+
+    // The source is what bounds this: a caller may ask to keep more than it supplied.
+    long long splice_end = std::llround((double)mask_start_seconds * (double)sample_rate);
+    splice_end = std::min(splice_end, (long long)source_n);
+    splice_end = std::min(splice_end, (long long)audio_n);
+    if (splice_end <= 0) return;
+
+    // Channel conform, matching the reference: same count passes through, a mono source repeats,
+    // and anything else downmixes to mono first.
+    const bool direct = source_n_ch == n_ch;
+    const bool mono_src = source_n_ch == 1;
+    auto src_at = [&](int c, long long s) -> float {
+        if (direct)   return source[(size_t)c * source_stride + s];
+        if (mono_src) return source[s];
+        float sum = 0.0f;
+        for (int sc = 0; sc < source_n_ch; sc++) sum += source[(size_t)sc * source_stride + s];
+        return sum / (float)source_n_ch;
+    };
+
+    long long xf = std::max(0LL, std::llround((double)params.xfade * (double)sample_rate));
+    const int xfade = (int)std::min(xf, splice_end / 2);
+    const long long hard_end = splice_end - xfade;
+
+    float gain = 1.0f;
+    if (params.gain_match) {
+        double ss_src = 0.0, ss_model = 0.0;
+        for (int c = 0; c < n_ch; c++) {
+            const float* out_ch = audio.data() + (size_t)c * audio_n;
+            for (long long s = 0; s < splice_end; s++) {
+                const double sv = src_at(c, s);   ss_src   += sv * sv;
+                const double av = out_ch[s];      ss_model += av * av;
+            }
+        }
+        const double count = (double)n_ch * (double)splice_end;
+        const float source_rms = (float)std::sqrt(ss_src / count);
+        const float model_rms  = (float)std::sqrt(ss_model / count);
+        // A silent source has no level to match; leave it alone rather than dividing by ~0.
+        if (source_rms > 1e-6f && model_rms > 1e-6f)
+            gain = std::min(4.0f, std::max(0.25f, model_rms / source_rms));
+    }
+
+    constexpr double kHalfPi = 1.5707963267948966;
+    for (int c = 0; c < n_ch; c++) {
+        float* out_ch = audio.data() + (size_t)c * audio_n;
+        for (long long s = 0; s < hard_end; s++) out_ch[s] = src_at(c, s) * gain;
+        // xfade == 1 is degenerate — a single point at phase 0 would be pure source, not a
+        // crossfade — so the reference keeps the model's sample there. Match it.
+        if (xfade > 1) {
+            for (int i = 0; i < xfade; i++) {
+                const double phase = kHalfPi * (double)i / (double)(xfade - 1);
+                const long long s = hard_end + i;
+                out_ch[s] = src_at(c, s) * gain * (float)std::cos(phase)
+                          + out_ch[s] * (float)std::sin(phase);
+            }
+        }
+    }
+
+    meta.applied            = true;
+    meta.splice_end_seconds = (float)((double)splice_end / (double)sample_rate);
+    meta.xfade_applied      = (float)((double)xfade / (double)sample_rate);
+    meta.gain               = gain;
+}
+
 } // namespace sa3

--- a/src/libsa3.cpp
+++ b/src/libsa3.cpp
@@ -21,6 +21,9 @@ struct sa3_context {
     std::string adapters_dir;
     int cpu_threads = 0;
     std::string device;  // remembered so the frugal-reload path keeps the same backend
+    // Everything computed after the sampler, for sa3_last_meta(). size stays 0 until the first
+    // successful generate, which is how the getter knows there is nothing to report yet.
+    sa3_meta last_meta{};
 };
 
 static void set_err(char* err, int n, const std::string& m) {
@@ -103,6 +106,7 @@ static int sa3_generate_impl(sa3_context* ctx, const sa3_request* req, const sa3
         } else {
             p.loudness = sa3::loudness_defaults_from_env();   // gary4local defaults + SA3_* env overrides
         }
+        p.splice = sa3::splice_defaults_from_env();           // ditto, SA3_CONTINUE_* (req_ex may override)
 
         if (req_ex) {
             std::string ierr;
@@ -114,6 +118,18 @@ static int sa3_generate_impl(sa3_context* ctx, const sa3_request* req, const sa3
             if (req_ex->decode_chunk_size > 0) {
                 p.decode_chunk_size = req_ex->decode_chunk_size;
                 p.decode_overlap = req_ex->decode_overlap > 0 ? req_ex->decode_overlap : 32;
+            }
+            if (req_ex->splice.set) {              // per-request splice (incl. the old behaviour: splice=0)
+                sa3::SpliceParams sp;
+                sp.enabled    = req_ex->splice.splice != 0;
+                sp.gain_match = req_ex->splice.gain_match != 0;
+                // 0 is a meaningful value for both (no pullback / no crossfade), so only a negative
+                // falls back to the default rather than the usual 0-means-default convention.
+                sp.mask_overlap = req_ex->splice.mask_overlap >= 0.0f ? req_ex->splice.mask_overlap : sp.mask_overlap;
+                sp.xfade        = req_ex->splice.xfade        >= 0.0f ? req_ex->splice.xfade        : sp.xfade;
+                std::string serr;
+                if (!sa3::validate_splice_params(sp, serr)) { set_err(err, err_len, "splice: " + serr); return 6; }
+                p.splice = sp;
             }
             if (req_ex->should_cancel) {
                 const sa3_cancel_cb cb = req_ex->should_cancel;
@@ -143,6 +159,26 @@ static int sa3_generate_impl(sa3_context* ctx, const sa3_request* req, const sa3
         std::memcpy(out->samples, r.samples.data(), n * sizeof(float));
         out->n_samp = r.n_samp; out->n_ch = r.n_ch; out->sample_rate = r.sample_rate;
         out->seed = p.seed;
+
+        sa3_meta m{};
+        m.size = (uint32_t)sizeof(sa3_meta);
+        m.seed = p.seed;
+        m.decoded_peak                = r.loudness.decoded_peak;
+        m.peak_normalize_gain_set     = r.loudness.peak_normalize_gain_set ? 1 : 0;
+        m.peak_normalize_gain         = r.loudness.peak_normalize_gain;
+        m.limiter_limited_fraction_set= r.loudness.limiter_limited_fraction_set ? 1 : 0;
+        m.limiter_limited_fraction    = r.loudness.limiter_limited_fraction;
+        m.safety_gain_set             = r.loudness.safety_gain_set ? 1 : 0;
+        m.safety_gain                 = r.loudness.safety_gain;
+        m.final_peak                  = r.loudness.final_peak;
+        m.latent_factor               = r.loudness.latent_factor;
+        m.splice_applied              = r.splice.applied ? 1 : 0;
+        m.splice_end_seconds          = r.splice.splice_end_seconds;
+        m.splice_xfade_applied        = r.splice.xfade_applied;
+        m.splice_gain                 = r.splice.gain;
+        m.mask_start_seconds          = r.splice.mask_start_seconds;
+        m.mask_overlap_applied        = r.splice.mask_overlap_applied;
+        ctx->last_meta = m;
         return 0;
     } catch (const std::exception& e) { set_err(err, err_len, e.what()); return 10; }
       catch (...)                     { set_err(err, err_len, "unknown error"); return 10; }
@@ -203,11 +239,26 @@ SA3_API void sa3_free_audio(sa3_audio* a) {
     if (a && a->samples) { std::free(a->samples); a->samples = nullptr; a->n_samp = 0; }
 }
 
+// Copy back only what BOTH sides know about: min(the caller's size, ours). A caller on an older
+// header gets the prefix it understands; one on a newer header sees a smaller size written back and
+// knows the tail it declared is untouched. This is what lets sa3_meta grow forever without an ABI
+// break, and without a new entry point per revision.
+SA3_API int sa3_last_meta(sa3_context* ctx, sa3_meta* out) {
+    if (!ctx || !out) return 1;
+    const uint32_t want = out->size;
+    if (want < sizeof(uint32_t)) return 2;              // too small to even carry the size back
+    if (ctx->last_meta.size == 0) return 3;             // no generation has completed on this ctx
+    const uint32_t n = want < sizeof(sa3_meta) ? want : (uint32_t)sizeof(sa3_meta);
+    std::memcpy(out, &ctx->last_meta, n);
+    out->size = n;
+    return 0;
+}
+
 SA3_API void sa3_unload(sa3_context* ctx) { if (ctx) ctx->pipe.reset(); }   // drop models; keep ctx
 
 SA3_API void sa3_free(sa3_context* ctx) { delete ctx; }
 
-SA3_API const char* sa3_version(void) { return "sa3.cpp libsa3 4"; }
+SA3_API const char* sa3_version(void) { return "sa3.cpp libsa3 5"; }
 
 SA3_API int sa3_convert_lora(const char* safetensors_path, const char* json_path,
                              const char* out_gguf_path, char* err, int err_len) {

--- a/src/libsa3.cpp
+++ b/src/libsa3.cpp
@@ -6,6 +6,7 @@
 #include "train_job.h"
 
 #include <cmath>
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
@@ -63,7 +64,8 @@ static bool apply_init_audio(const sa3_init_audio& in, sa3::GenParams& p, std::s
 }
 
 static int sa3_generate_impl(sa3_context* ctx, const sa3_request* req, const sa3_request_ex* req_ex,
-                             sa3_audio* out, char* err, int err_len) {
+                             const sa3_splice* splice_override, sa3_audio* out,
+                             char* err, int err_len) {
     if (!ctx || !req || !out) { set_err(err, err_len, "null argument"); return 1; }
     out->samples = nullptr; out->n_samp = 0; out->n_ch = 0; out->sample_rate = 0; out->seed = 0;
     try {
@@ -119,14 +121,14 @@ static int sa3_generate_impl(sa3_context* ctx, const sa3_request* req, const sa3
                 p.decode_chunk_size = req_ex->decode_chunk_size;
                 p.decode_overlap = req_ex->decode_overlap > 0 ? req_ex->decode_overlap : 32;
             }
-            if (req_ex->splice.set) {              // per-request splice (incl. the old behaviour: splice=0)
+            if (splice_override && splice_override->set) { // per-request splice (incl. old behaviour: splice=0)
                 sa3::SpliceParams sp;
-                sp.enabled    = req_ex->splice.splice != 0;
-                sp.gain_match = req_ex->splice.gain_match != 0;
+                sp.enabled    = splice_override->splice != 0;
+                sp.gain_match = splice_override->gain_match != 0;
                 // 0 is a meaningful value for both (no pullback / no crossfade), so only a negative
                 // falls back to the default rather than the usual 0-means-default convention.
-                sp.mask_overlap = req_ex->splice.mask_overlap >= 0.0f ? req_ex->splice.mask_overlap : sp.mask_overlap;
-                sp.xfade        = req_ex->splice.xfade        >= 0.0f ? req_ex->splice.xfade        : sp.xfade;
+                sp.mask_overlap = splice_override->mask_overlap >= 0.0f ? splice_override->mask_overlap : sp.mask_overlap;
+                sp.xfade        = splice_override->xfade        >= 0.0f ? splice_override->xfade        : sp.xfade;
                 std::string serr;
                 if (!sa3::validate_splice_params(sp, serr)) { set_err(err, err_len, "splice: " + serr); return 6; }
                 p.splice = sp;
@@ -227,12 +229,20 @@ SA3_API sa3_context* sa3_init_ex(const sa3_config_ex* cfg, char* err, int err_le
 }
 
 SA3_API int sa3_generate(sa3_context* ctx, const sa3_request* req, sa3_audio* out, char* err, int err_len) {
-    return sa3_generate_impl(ctx, req, nullptr, out, err, err_len);
+    return sa3_generate_impl(ctx, req, nullptr, nullptr, out, err, err_len);
 }
 
 SA3_API int sa3_generate_ex(sa3_context* ctx, const sa3_request_ex* req, sa3_audio* out, char* err, int err_len) {
     if (!req) { set_err(err, err_len, "null argument"); return 1; }
-    return sa3_generate_impl(ctx, &req->request, req, out, err, err_len);
+    return sa3_generate_impl(ctx, &req->request, req, nullptr, out, err, err_len);
+}
+
+SA3_API int sa3_generate_v2(sa3_context* ctx, const sa3_request_v2* req, sa3_audio* out, char* err, int err_len) {
+    if (!req) { set_err(err, err_len, "null v2 request"); return 1; }
+    const size_t required = offsetof(sa3_request_v2, splice) + sizeof(sa3_splice);
+    if (req->size < required) { set_err(err, err_len, "v2 request size is too small"); return 1; }
+    return sa3_generate_impl(ctx, &req->request.request, &req->request, &req->splice,
+                             out, err, err_len);
 }
 
 SA3_API void sa3_free_audio(sa3_audio* a) {

--- a/src/libsa3.h
+++ b/src/libsa3.h
@@ -125,6 +125,31 @@ enum {
     SA3_INIT_AUDIO_INPAINT = 2
 };
 
+/* Continuation source splicing. Defaults mirror gary4local (0.2 s mask overlap, 30 ms equal-power
+ * crossfade, RMS gain match on) — see docs/CONTINUATION.md. Leave `set = 0` (the zero-initialized
+ * default) to use those plus any SA3_CONTINUE_* env overrides. Set `set = 1` to drive it
+ * per-request, including the old un-spliced behaviour (`splice = 0`).
+ *
+ * Splice is ON at `set = 0`, the way loudness normalization already is: a zero-initialized request
+ * today gets gary4local's +2 dB normalize and -0.3 dB limiter rather than raw output, because the
+ * library's position is that its defaults are the tuned ones. This is the same kind of thing.
+ *
+ * Continuation regenerates a window over source audio that has round-tripped through the
+ * autoencoder, so the region the model was told to KEEP still comes back carrying the codec's
+ * artefacts — and each continuation compounds the last one's. The splice pastes the original
+ * samples back over that region after decode and before loudness shaping, which takes the audio
+ * off that treadmill entirely and takes the pressure off decoder/encoder LoRAs.
+ *
+ * Env overrides (set = 0 only): SA3_CONTINUE_SPLICE_SOURCE, SA3_CONTINUE_MASK_OVERLAP,
+ * SA3_CONTINUE_SPLICE_XFADE, SA3_CONTINUE_SPLICE_GAIN_MATCH. */
+typedef struct {
+    int   set;                  /* 0 = library defaults; 1 = use the fields below */
+    int   splice;               /* bool: restore the source head after decode */
+    float mask_overlap;         /* s of source the model regenerates; <0 -> 0.2. keeps >= 50 ms */
+    float xfade;                /* s of equal-power crossfade at the seam; <0 -> 0.03 */
+    int   gain_match;           /* bool: RMS-match the restored head, clamped to [0.25, 4.0] */
+} sa3_splice;
+
 /* Optional audio input for sa3_generate_ex(). `samples` is PLANAR float audio laid out as
  * samples[ch * n_samp + sample] at sample_rate Hz. The pipeline resamples to 44.1 kHz internally.
  *
@@ -135,6 +160,15 @@ enum {
  *   Inpainting/continuation. Requires a local-conditioning DiT. The window [inpaint_start,
  *   inpaint_end) is in seconds; audio outside the window is kept, and inpaint_end can extend the
  *   total output past the supplied source audio.
+ *
+ *   NOTE — with splicing on (the default; see sa3_splice on sa3_request_ex), `inpaint_start` means
+ *   "where the source ends and the continuation should musically begin", and the library owns the
+ *   mechanics from there: it pulls the sampler's window back by `mask_overlap` so the model
+ *   regenerates the handoff rather than butting against a hard boundary, then splices the source
+ *   back up to that same pulled-back point. This is the ONE place turning the splice on changes
+ *   what an existing field means — a caller passing inpaint_start = source duration (the usual
+ *   continuation shape) gets the improvement without changing its call. Set `mask_overlap = 0` for
+ *   literally the window you asked for.
  */
 typedef struct {
     int          mode;
@@ -165,6 +199,12 @@ typedef struct {
     int decode_overlap;
     sa3_cancel_cb should_cancel;
     void* cancel_user;
+    /* Continuation source splicing; set=0 -> gary4local defaults. Ignored unless
+     * init_audio.mode == SA3_INIT_AUDIO_INPAINT. It describes the audio in init_audio rather than
+     * the request, but it lives here because NEW FIELDS GO AT THE END: sa3_init_audio sits by
+     * value above, so growing it would shift every field below it for a caller compiled against
+     * the old header, where an appended field costs them nothing. */
+    sa3_splice splice;
 } sa3_request_ex;
 
 /* Decoded audio. samples is PLANAR by channel: samples[c * n_samp + s]. Free with sa3_free_audio(). */
@@ -187,6 +227,55 @@ SA3_API int sa3_generate(sa3_context* ctx, const sa3_request* req, sa3_audio* ou
 
 /* Extended generate with raw init audio for audio2audio and inpaint/continuation. */
 SA3_API int sa3_generate_ex(sa3_context* ctx, const sa3_request_ex* req, sa3_audio* out, char* err, int err_len);
+
+/* Metadata for the most recent generation on a context.
+ *
+ * Everything computed after the sampler used to die at the ABI: sa3_audio returns samples, n_samp,
+ * n_ch, sample_rate and seed, so a client had no way to learn what the loudness stage measured or
+ * whether the splice fired. This is that channel.
+ *
+ * `size` is the whole point of the shape. Set out->size = sizeof(sa3_meta) before calling; the
+ * library fills min(your size, its own) and writes back how much it actually filled. Fields get
+ * APPENDED here forever — an older client passes a smaller size and gets the prefix it understands,
+ * a newer client against an older library sees a smaller size written back and knows the tail is
+ * untouched. Check the returned `size` before reading a field you are not sure the library has.
+ *
+ * Zero-initialize the struct: what the library does not fill stays zero either way. */
+typedef struct {
+    uint32_t size;                      /* in: sizeof(sa3_meta); out: bytes the library filled */
+
+    uint64_t seed;
+
+    /* Loudness — what it measured, and what it applied. The *_set flags distinguish "the stage ran
+     * and the value is 1.0" from "the stage was disabled and never ran". */
+    float decoded_peak;
+    int   peak_normalize_gain_set;
+    float peak_normalize_gain;
+    int   limiter_limited_fraction_set;
+    float limiter_limited_fraction;
+    int   safety_gain_set;
+    float safety_gain;
+    float final_peak;
+    float latent_factor;
+
+    /* Continuation splice. All zero when the request was not an inpaint, or the splice was off. */
+    int   splice_applied;
+    float splice_end_seconds;
+    float splice_xfade_applied;
+    float splice_gain;
+    float mask_start_seconds;           /* what the sampler used, AFTER the overlap pullback */
+    float mask_overlap_applied;         /* the pullback it actually got, after clamping */
+} sa3_meta;
+
+/* Fill `out` with metadata for the most recent successful generation on this context. Returns 0 on
+ * success, non-zero if ctx/out is NULL, out->size is too small to hold even `size`, or no
+ * generation has completed on this context yet.
+ *
+ * It is a getter tied to the previous call rather than an out-param on sa3_generate_ex(), which is
+ * what keeps sa3_audio and sa3_generate_ex ABI-frozen while this struct grows. "Most recent" is
+ * unambiguous because a context is NOT reentrant (see the banner) — serialize per context, and read
+ * the meta before the next generate on it. */
+SA3_API int sa3_last_meta(sa3_context* ctx, sa3_meta* out);
 
 /* Release the sample buffer allocated by sa3_generate(). */
 SA3_API void sa3_free_audio(sa3_audio* audio);

--- a/src/libsa3.h
+++ b/src/libsa3.h
@@ -1,8 +1,8 @@
 /* libsa3 — a tiny C ABI over the sa3 generation pipeline, for embedding SA3 directly in a host
  * (e.g. a JUCE / IPlug2 plugin) without spawning the CLI or the HTTP server.
  *
- * Lifecycle:   sa3_init() -> sa3_generate()/sa3_generate_ex() [* N] -> sa3_free()
- * Ownership:   sa3_generate()/sa3_generate_ex() allocate sa3_audio.samples; release it with
+ * Lifecycle:   sa3_init() -> sa3_generate()/sa3_generate_ex()/sa3_generate_v2() [* N] -> sa3_free()
+ * Ownership:   generation calls allocate sa3_audio.samples; release it with
  *              sa3_free_audio() (same
  *              allocator/CRT as the library — do NOT free() it yourself across a DLL boundary).
  * Threading:   a context is NOT reentrant — serialize sa3_generate() calls per context.
@@ -161,7 +161,7 @@ typedef struct {
  *   inpaint_end) is in seconds; audio outside the window is kept, and inpaint_end can extend the
  *   total output past the supplied source audio.
  *
- *   NOTE — with splicing on (the default; see sa3_splice on sa3_request_ex), `inpaint_start` means
+ *   NOTE — with splicing on (the default; see sa3_splice on sa3_request_v2), `inpaint_start` means
  *   "where the source ends and the continuation should musically begin", and the library owns the
  *   mechanics from there: it pulls the sampler's window back by `mask_overlap` so the model
  *   regenerates the handoff rather than butting against a hard boundary, then splices the source
@@ -199,13 +199,17 @@ typedef struct {
     int decode_overlap;
     sa3_cancel_cb should_cancel;
     void* cancel_user;
-    /* Continuation source splicing; set=0 -> gary4local defaults. Ignored unless
-     * init_audio.mode == SA3_INIT_AUDIO_INPAINT. It describes the audio in init_audio rather than
-     * the request, but it lives here because NEW FIELDS GO AT THE END: sa3_init_audio sits by
-     * value above, so growing it would shift every field below it for a caller compiled against
-     * the old header, where an appended field costs them nothing. */
-    sa3_splice splice;
 } sa3_request_ex;
+
+/* Size-tagged request for options added after sa3_request_ex was published. Keep sa3_request_ex
+ * frozen: an older caller allocates only its historical size, so a newer library cannot safely
+ * inspect an appended tail. `size` makes this request append-only in both directions. */
+typedef struct {
+    uint32_t       size;                 /* set to sizeof(sa3_request_v2) */
+    sa3_request_ex request;
+    /* Ignored unless request.init_audio.mode == SA3_INIT_AUDIO_INPAINT. set=0 uses defaults. */
+    sa3_splice     splice;
+} sa3_request_v2;
 
 /* Decoded audio. samples is PLANAR by channel: samples[c * n_samp + s]. Free with sa3_free_audio(). */
 typedef struct {
@@ -227,6 +231,9 @@ SA3_API int sa3_generate(sa3_context* ctx, const sa3_request* req, sa3_audio* ou
 
 /* Extended generate with raw init audio for audio2audio and inpaint/continuation. */
 SA3_API int sa3_generate_ex(sa3_context* ctx, const sa3_request_ex* req, sa3_audio* out, char* err, int err_len);
+
+/* Size-tagged generation request. Use this for per-request continuation-splice controls. */
+SA3_API int sa3_generate_v2(sa3_context* ctx, const sa3_request_v2* req, sa3_audio* out, char* err, int err_len);
 
 /* Metadata for the most recent generation on a context.
  *

--- a/src/sa3_pipeline.h
+++ b/src/sa3_pipeline.h
@@ -603,6 +603,12 @@ struct GenParams {
     // normalize decoded audio to +2 dB peak, then catch hot LoRAs with a gentle -0.3 dB limiter.
     LoudnessParams loudness;
 
+    // Continuation source splicing (inpaint + init audio only; see audio_post.h). Defaults mirror
+    // gary4local and are ON: inpaint_start is read as "where the source ends", the mask is pulled
+    // back into the source by mask_overlap, and after decode the source is pasted back over
+    // everything up to that same point. Set enabled = false for the old, un-spliced behaviour.
+    SpliceParams splice;
+
     // Residency for THIS request (see the header banner). Default true = resident (keep models loaded
     // for the next request — the right default when a server/lib is reused). Set false for frugal
     // early-free: fits long-form on small VRAM at the cost of a reload next request. The one-shot CLI
@@ -624,6 +630,7 @@ struct GenResult {
     int n_ch = 2;
     int sample_rate = 44100;
     LoudnessMeta loudness;
+    SpliceMeta splice;
 };
 
 // Holds the loaded models for the life of the process. Move-only (owns the backend + buffers).
@@ -833,6 +840,7 @@ inline GenResult Pipeline::generate(const GenParams& params) {
 
     // ---------- init audio: pad + derive output T (overrides params.frames) ----------
     std::vector<float> init_audio; int init_L = 0;
+    int init_src_n = 0;    // valid samples in init_audio; init_L is the padded stride, not this
     if (has_init) {
         int n_samp = params.init_n_samp; const int n_ch = params.init_n_ch;
         // resample the init source to the model rate (44.1 kHz) if the caller passed another rate.
@@ -854,11 +862,28 @@ inline GenResult Pipeline::generate(const GenParams& params) {
         init_L = ((want + mult - 1) / mult) * mult;
         init_audio.assign((size_t)init_L * n_ch, 0.0f);
         const int copy = std::min(n_samp, init_L);
+        init_src_n = copy;
         for (int c = 0; c < n_ch; c++)
             memcpy(&init_audio[(size_t)c*init_L], &raw[(size_t)c*n_samp], copy * sizeof(float));
         frames = init_L / ds;
         printf("%s: init %.2fs -> output T=%d (%.2fs)\n",
                inpaint ? "inpaint" : "audio2audio", (float)n_samp/44100.0f, frames, (float)init_L/44100.0f);
+    }
+
+    // ---------- continuation splice: where the mask starts, decided once ----------
+    // With the splice on, inpaint_start means "where the source ends and the continuation should
+    // musically begin". Pull the sampler's window back into the source from there so the model
+    // regenerates the handoff instead of butting against a hard boundary, and remember the pulled
+    // back point: the splice restores the source up to exactly it after decode. Both halves reading
+    // the same number is what makes the seam land where the crossfade expects it.
+    SpliceMeta splice_meta;
+    float mask_start = inpaint_start;
+    const bool splice_source = inpaint && has_init && params.splice.enabled && inpaint_start > 0.0f;
+    if (splice_source) {
+        continuation_mask_bounds(inpaint_start, params.splice.mask_overlap,
+                                 splice_meta.mask_overlap_applied, mask_start);
+        printf("continue: mask pulled back %.3fs to %.3fs (source %.3fs), splicing on decode\n",
+               splice_meta.mask_overlap_applied, mask_start, inpaint_start);
     }
 
     // text2music: an odd latent frame count trips the SAME chunked-attention reshape (hard
@@ -1156,7 +1181,7 @@ inline GenResult Pipeline::generate(const GenParams& params) {
     std::vector<float> localb;
     if (inpaint) {
         auto ceil_div = [](int a, int b){ return (a + b - 1) / b; };
-        const int sa = (int)(inpaint_start * 44100.0f);
+        const int sa = (int)(mask_start * 44100.0f);
         const int ea = inpaint_end < 0 ? T*ds : (int)(inpaint_end * 44100.0f);
         const int f0 = std::max(0, std::min(T, ceil_div(sa, ds)));
         const int f1 = std::max(f0, std::min(T, ceil_div(ea, ds)));
@@ -1485,6 +1510,13 @@ inline GenResult Pipeline::generate(const GenParams& params) {
             memcpy(&tr[(size_t)c*out_n_samp], &ab[(size_t)c*n_samp], (size_t)copy_n*sizeof(float));
         ab = std::move(tr);
     }
+    if (splice_source)
+        splice_continuation_source(ab, out_n_samp, n_ch, init_audio.data(), init_src_n, init_L,
+                                   n_ch, mask_start, 44100, params.splice, splice_meta);
+    if (splice_meta.applied)
+        printf("continue splice: kept 0-%.3fs, xfade %.0fms, gain %.3f\n",
+               splice_meta.splice_end_seconds, splice_meta.xfade_applied * 1000.0f, splice_meta.gain);
+
     apply_audio_loudness(ab, params.loudness, loudness_meta);
 
     if (params.on_progress) params.on_progress({"done", steps, steps, 1.0f});
@@ -1495,6 +1527,7 @@ inline GenResult Pipeline::generate(const GenParams& params) {
     r.n_ch = n_ch;
     r.sample_rate = 44100;
     r.loudness = loudness_meta;
+    r.splice = splice_meta;
     return r;
 }
 

--- a/tests/continuation_splice_test.cpp
+++ b/tests/continuation_splice_test.cpp
@@ -1,0 +1,232 @@
+// The splice arithmetic alone — no model, synthetic buffers. Proves the seam lands where the mask
+// bounds say it does, and that the degenerate cases the reference handles are handled the same way.
+#include "audio_post.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+static int expect(bool ok, const char* msg) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", msg); return 1; }
+    return 0;
+}
+
+static bool near(float a, float b, float tol = 1e-5f) { return std::fabs(a - b) <= tol; }
+
+// A DC buffer per channel makes every assertion below readable: the restored head is the source
+// level, the untouched tail is the model level, and the crossfade is the two in known proportion.
+static std::vector<float> dc(int n_samp, int n_ch, float value) {
+    return std::vector<float>((size_t)n_samp * n_ch, value);
+}
+
+int main() {
+    int fails = 0;
+    const int sr = 44100;
+
+    // ---- mask bounds: the pullback, and the floor under it ----
+    {
+        float ov = 0.0f, ms = 0.0f;
+        sa3::continuation_mask_bounds(10.0f, 0.2f, ov, ms);
+        fails += expect(near(ov, 0.2f) && near(ms, 9.8f), "10 s source, 0.2 s overlap -> mask at 9.8 s");
+
+        sa3::continuation_mask_bounds(10.0f, 0.0f, ov, ms);
+        fails += expect(near(ov, 0.0f) && near(ms, 10.0f), "zero overlap keeps the requested window");
+
+        // A source shorter than the requested overlap still leaves 50 ms of real audio.
+        sa3::continuation_mask_bounds(0.1f, 0.2f, ov, ms);
+        fails += expect(near(ov, 0.05f) && near(ms, 0.05f), "short source clamps to 50 ms kept");
+
+        sa3::continuation_mask_bounds(0.02f, 0.2f, ov, ms);
+        fails += expect(near(ov, 0.0f) && near(ms, 0.02f), "source under 50 ms gets no pullback");
+
+        sa3::continuation_mask_bounds(10.0f, -1.0f, ov, ms);
+        fails += expect(near(ov, 0.0f) && near(ms, 10.0f), "negative overlap is clamped to 0");
+    }
+
+    // ---- the ordinary splice: head restored, tail untouched, equal-power seam between ----
+    {
+        const int n = sr, n_ch = 2;                     // 1 s of output
+        std::vector<float> audio = dc(n, n_ch, 0.5f);
+        const std::vector<float> src = dc(n, n_ch, 0.5f);   // same level: gain match is a no-op
+        sa3::SpliceParams p; p.xfade = 0.03f;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.5f, sr, p, m);
+
+        const int splice_end = sr / 2, xf = (int)std::llround(0.03 * sr);
+        fails += expect(m.applied, "splice applied");
+        fails += expect(near(m.splice_end_seconds, 0.5f), "splice_end reported in seconds");
+        fails += expect(near(m.xfade_applied, (float)xf / sr), "xfade reported in seconds");
+        fails += expect(near(m.gain, 1.0f), "matched levels -> unit gain");
+        // Everything past the mask start is the model's, untouched.
+        fails += expect(near(audio[splice_end + 10], 0.5f), "tail is the model's audio");
+        fails += expect(near(audio[(size_t)n + splice_end + 10], 0.5f), "tail untouched on ch 1");
+    }
+
+    // ---- distinguishable levels: prove which samples came from where ----
+    {
+        const int n = 1000, n_ch = 1, rate = 1000;      // 1 s at 1 kHz, so seconds are samples/1000
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        const std::vector<float> src = dc(n, n_ch, 1.0f);
+        sa3::SpliceParams p; p.xfade = 0.100f; p.gain_match = false;   // 100 samples of crossfade
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.5f, rate, p, m);
+
+        const int splice_end = 500, xf = 100, hard_end = splice_end - xf;
+        // Equal-power: cos + sin over a quarter turn, both operands 1.0.
+        for (int i = 0; i < xf; i++) {
+            const double ph = 1.5707963267948966 * (double)i / (double)(xf - 1);
+            const float want = (float)(std::cos(ph) + std::sin(ph));
+            if (!near(audio[hard_end + i], want, 1e-4f)) {
+                fails += expect(false, "crossfade follows cos/sin");
+                break;
+            }
+        }
+        fails += expect(near(audio[hard_end - 1], 1.0f), "hard region is pure source");
+        fails += expect(near(audio[splice_end], 1.0f), "first model sample after the seam");
+    }
+
+    // ---- xfade longer than the window: clamped to half, never past the splice ----
+    {
+        const int n = 1000, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 0.5f);
+        const std::vector<float> src = dc(n, n_ch, 0.5f);
+        sa3::SpliceParams p; p.xfade = 10.0f; p.gain_match = false;   // absurd: 10 s into a 0.1 s head
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.1f, rate, p, m);
+        fails += expect(m.applied && near(m.xfade_applied, 0.05f), "xfade clamps to half the window");
+        fails += expect(near(audio[200], 0.5f), "nothing written past splice_end");
+    }
+
+    // ---- xfade == 1 sample: degenerate, so the model's sample stands ----
+    {
+        const int n = 100, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        const std::vector<float> src = dc(n, n_ch, 0.25f);
+        sa3::SpliceParams p; p.xfade = 0.001f; p.gain_match = false;   // exactly one sample
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.05f, rate, p, m);
+        fails += expect(near(m.xfade_applied, 0.001f), "one-sample xfade reported");
+        fails += expect(near(audio[48], 0.25f), "hard region still source");
+        fails += expect(near(audio[49], 1.0f), "the single xfade sample keeps the model's value");
+    }
+
+    // ---- splice_end == 0: mask start at the very front, nothing to restore ----
+    {
+        const int n = 100, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        const std::vector<float> src = dc(n, n_ch, 0.25f);
+        sa3::SpliceParams p;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.0f, rate, p, m);
+        fails += expect(!m.applied && near(audio[0], 1.0f), "mask start 0 -> untouched");
+    }
+
+    // ---- mono source into stereo output: broadcast, not silence on ch 1 ----
+    {
+        const int n = 100, n_ch = 2, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        const std::vector<float> src = dc(n, 1, 0.25f);
+        sa3::SpliceParams p; p.xfade = 0.0f; p.gain_match = false;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, 1, 0.05f, rate, p, m);
+        fails += expect(near(audio[10], 0.25f), "mono source reaches ch 0");
+        fails += expect(near(audio[(size_t)n + 10], 0.25f), "mono source repeats onto ch 1");
+    }
+
+    // ---- stereo source into mono output: downmixed ----
+    {
+        const int n = 100, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        std::vector<float> src((size_t)n * 2, 0.0f);
+        for (int s = 0; s < n; s++) { src[s] = 0.2f; src[(size_t)n + s] = 0.6f; }
+        sa3::SpliceParams p; p.xfade = 0.0f; p.gain_match = false;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, 2, 0.05f, rate, p, m);
+        fails += expect(near(audio[10], 0.4f), "stereo source downmixes to the mono mean");
+    }
+
+    // ---- a silent source: gain match must not divide by ~0 ----
+    {
+        const int n = 100, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        const std::vector<float> src = dc(n, n_ch, 0.0f);
+        sa3::SpliceParams p; p.xfade = 0.0f;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.05f, rate, p, m);
+        fails += expect(near(m.gain, 1.0f) && std::isfinite(audio[10]), "silent source -> unit gain");
+        fails += expect(near(audio[10], 0.0f), "silence is still restored, just unscaled");
+    }
+
+    // ---- gain match: pulls a quiet head up to the model's level, and clamps ----
+    {
+        const int n = 100, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 0.8f);
+        const std::vector<float> src = dc(n, n_ch, 0.4f);
+        sa3::SpliceParams p; p.xfade = 0.0f;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.05f, rate, p, m);
+        fails += expect(near(m.gain, 2.0f), "gain = model_rms / source_rms");
+        fails += expect(near(audio[10], 0.8f), "restored head sits at the model's level");
+    }
+    {
+        const int n = 100, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        const std::vector<float> src = dc(n, n_ch, 0.001f);   // ratio 1000, way past the clamp
+        sa3::SpliceParams p; p.xfade = 0.0f;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.05f, rate, p, m);
+        fails += expect(near(m.gain, 4.0f), "gain clamps at 4.0");
+    }
+    {
+        const int n = 100, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 0.001f);
+        const std::vector<float> src = dc(n, n_ch, 1.0f);
+        sa3::SpliceParams p; p.xfade = 0.0f;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.05f, rate, p, m);
+        fails += expect(near(m.gain, 0.25f), "gain clamps at 0.25");
+    }
+
+    // ---- a source shorter than the mask start bounds the splice ----
+    {
+        const int n = 1000, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        const std::vector<float> src = dc(300, n_ch, 0.25f);
+        sa3::SpliceParams p; p.xfade = 0.0f; p.gain_match = false;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), 300, 300, n_ch, 0.5f, rate, p, m);
+        fails += expect(near(m.splice_end_seconds, 0.3f), "splice_end clamps to the source length");
+        fails += expect(near(audio[299], 0.25f) && near(audio[300], 1.0f), "splice stops at the source end");
+    }
+
+    // ---- a padded source buffer: stride is not the valid length ----
+    {
+        const int n = 1000, n_ch = 2, rate = 1000;
+        const int src_n = 400, stride = 512;               // the pipeline's generation buffer shape
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        std::vector<float> src((size_t)stride * n_ch, 0.0f);
+        for (int c = 0; c < n_ch; c++)
+            for (int s = 0; s < src_n; s++) src[(size_t)c * stride + s] = 0.25f;
+        sa3::SpliceParams p; p.xfade = 0.0f; p.gain_match = false;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), src_n, stride, n_ch, 0.5f, rate, p, m);
+        fails += expect(near(m.splice_end_seconds, 0.4f), "valid length bounds the splice, not the stride");
+        fails += expect(near(audio[(size_t)n + 399], 0.25f), "ch 1 reads at the source stride");
+        fails += expect(near(audio[(size_t)n + 400], 1.0f), "the zero padding is never pasted");
+    }
+
+    // ---- disabled: byte-for-byte untouched ----
+    {
+        const int n = 100, n_ch = 1, rate = 1000;
+        std::vector<float> audio = dc(n, n_ch, 1.0f);
+        const std::vector<float> src = dc(n, n_ch, 0.25f);
+        sa3::SpliceParams p; p.enabled = false;
+        sa3::SpliceMeta m;
+        sa3::splice_continuation_source(audio, n, n_ch, src.data(), n, n, n_ch, 0.05f, rate, p, m);
+        fails += expect(!m.applied && near(audio[0], 1.0f), "splice off -> untouched");
+    }
+
+    if (fails) return 1;
+    std::printf("continuation_splice_test: ok\n");
+    return 0;
+}

--- a/tools/sa3-generate.cpp
+++ b/tools/sa3-generate.cpp
@@ -59,6 +59,7 @@ int main(int argc, char** argv) {
     float cfg_scale = 1.0f, cfg_rescale = 0.0f, apg_scale = 1.0f, cfg_norm_threshold = 0.0f;
     float cfg_interval_min = 0.0f, cfg_interval_max = 1.0f;
     sa3::LoudnessParams loudness = sa3::loudness_defaults_from_env();
+    sa3::SpliceParams splice = sa3::splice_defaults_from_env();   // continuation splice; SA3_CONTINUE_*
     for (int i = 1; i < argc; i++) {
         if      (!strcmp(argv[i], "--model")  && i+1 < argc) model_variant = argv[++i];
         else if (!strcmp(argv[i], "--encoding") && i+1 < argc) encoding = argv[++i];
@@ -135,6 +136,10 @@ int main(int argc, char** argv) {
         }
         else if (!strcmp(argv[i], "--no-limiter")) loudness.limiter_enabled = false;
         else if (!strcmp(argv[i], "--limiter-knee") && i+1 < argc) loudness.limiter_knee = (float)atof(argv[++i]);
+        else if (!strcmp(argv[i], "--no-splice")) splice.enabled = false;
+        else if (!strcmp(argv[i], "--mask-overlap") && i+1 < argc) splice.mask_overlap = (float)atof(argv[++i]);
+        else if (!strcmp(argv[i], "--splice-xfade") && i+1 < argc) splice.xfade = (float)atof(argv[++i]);
+        else if (!strcmp(argv[i], "--no-splice-gain-match")) splice.gain_match = false;
     }
     // --model <variant>: fill the five base ggufs from <models-dir> by the naming convention.
     // Explicit --tok/--t5/--cond/--dit/--same still win (override per-slot).
@@ -203,7 +208,8 @@ int main(int argc, char** argv) {
                         "                     | --tok <f> --t5 <f> --cond <f> --dit <f> --same <f>)\n"
                         "                     --prompt \"...\" [--lora NAME|PATH [--lora-strength S]]... [--duration SEC | --frames N] [--steps N] [--threads N] [--seed S]\n"
                         "                     [--dist-shift LogSNR|Flux|Full|None [--dist-shift-params p1,p2,p3,p4]] [--duration-padding SEC]\n"
-                        "                     [--cfg-scale S [--negative-prompt \"...\"] [--cfg-rescale R] [--cfg-interval min,max] [--apg-scale A] [--cfg-norm-threshold T]] [--out song.wav]\n");
+                        "                     [--cfg-scale S [--negative-prompt \"...\"] [--cfg-rescale R] [--cfg-interval min,max] [--apg-scale A] [--cfg-norm-threshold T]] [--out song.wav]\n"
+                        "                     continuation splice (with --init + --inpaint-start): [--no-splice] [--mask-overlap SEC] [--splice-xfade SEC] [--no-splice-gain-match]\n");
         return 1;
     }
     if (duration_set && frames_set) {
@@ -250,6 +256,11 @@ int main(int argc, char** argv) {
         fprintf(stderr, "invalid loudness settings: %s\n", loudness_err.c_str());
         return 1;
     }
+    std::string splice_err;
+    if (!sa3::validate_splice_params(splice, splice_err)) {
+        fprintf(stderr, "invalid splice settings: %s\n", splice_err.c_str());
+        return 1;
+    }
 
     // ---------- build model paths + the request, then run the shared pipeline ----------
     sa3::ModelPaths paths;
@@ -271,6 +282,7 @@ int main(int argc, char** argv) {
     params.decode_chunk_size = decode_chunk_size;
     params.decode_overlap    = decode_overlap;
     params.loudness          = loudness;
+    params.splice            = splice;
     params.dist_shift        = dist_shift;
     params.ds_p1 = ds_p1; params.ds_p2 = ds_p2; params.ds_p3 = ds_p3; params.ds_p4 = ds_p4;
     params.duration_padding_sec = duration_padding_sec;

--- a/tools/sa3-libtest.c
+++ b/tools/sa3-libtest.c
@@ -2,6 +2,10 @@
  * This is exactly the call sequence a JUCE / IPlug2 host would use:
  *   sa3_init -> sa3_generate (with a progress callback) -> use samples -> sa3_free_audio -> sa3_free.
  *   usage: sa3-libtest ["prompt"] [out.wav] [cpu_threads]
+ *
+ * It then continues that clip through sa3_generate_ex to exercise the continuation splice, and
+ * reads sa3_last_meta twice — once with a full struct, once with a deliberately undersized one,
+ * which is the only thing that tests the `size` contract at all.
  */
 #include "libsa3.h"
 
@@ -78,7 +82,82 @@ int main(int argc, char** argv) {
     write_wav(out, audio.samples, audio.n_samp, audio.n_ch, audio.sample_rate);
     printf("wrote %s\n", out);
 
+    /* Everything the pipeline computed after the sampler. Zero the struct and declare its size;
+       what the library does not fill stays zero. */
+    sa3_meta meta;
+    memset(&meta, 0, sizeof meta);
+    meta.size = (uint32_t)sizeof meta;
+    if (sa3_last_meta(ctx, &meta) != 0) { fprintf(stderr, "sa3_last_meta failed\n"); sa3_free_audio(&audio); sa3_free(ctx); return 1; }
+    printf("meta: filled %u/%u bytes, decoded peak %.4f, normalize gain %.4f, limited %.4f%%, final peak %.4f\n",
+           meta.size, (unsigned)sizeof meta, meta.decoded_peak, meta.peak_normalize_gain,
+           meta.limiter_limited_fraction * 100.0f, meta.final_peak);
+
+    /* The size contract, from the other side: a caller built against an older header declares a
+       SHORTER struct. It must get the prefix it understands and be told how much that was — never
+       a write past the end of what it allocated. Casting a truncated struct is exactly what such a
+       caller does at the ABI level, which is why the test does it here. */
+    {
+        struct { uint32_t size; uint64_t seed; float decoded_peak; } old_client;
+        memset(&old_client, 0, sizeof old_client);
+        old_client.size = (uint32_t)sizeof old_client;
+        if (sa3_last_meta(ctx, (sa3_meta*)&old_client) != 0) {
+            fprintf(stderr, "sa3_last_meta rejected an undersized struct\n");
+            sa3_free_audio(&audio); sa3_free(ctx); return 1;
+        }
+        if (old_client.size != (uint32_t)sizeof old_client || old_client.decoded_peak != meta.decoded_peak) {
+            fprintf(stderr, "undersized sa3_meta came back wrong: size %u, peak %.6f\n",
+                    old_client.size, old_client.decoded_peak);
+            sa3_free_audio(&audio); sa3_free(ctx); return 1;
+        }
+        printf("meta: an old client asking for %u bytes got %u back, prefix intact\n",
+               (unsigned)sizeof old_client, old_client.size);
+    }
+
+    /* ---- continuation: feed the clip back in and extend it, with the source splice on ----
+       inpaint_start is where the source ends; the library pulls the sampler's mask back into it by
+       mask_overlap and pastes the original samples over everything up to that same point. A
+       zero-initialized sa3_splice (set = 0) asks for gary4local's tuned defaults. */
+    const int src_n = audio.n_samp, src_ch = audio.n_ch, src_sr = audio.sample_rate;
+    float* src = (float*)malloc((size_t)src_n * src_ch * sizeof(float));
+    if (!src) { fprintf(stderr, "out of memory\n"); sa3_free_audio(&audio); sa3_free(ctx); return 1; }
+    memcpy(src, audio.samples, (size_t)src_n * src_ch * sizeof(float));
     sa3_free_audio(&audio);
+
+    const float src_seconds = (float)src_n / (float)src_sr;
+    sa3_request_ex rx;
+    memset(&rx, 0, sizeof rx);
+    rx.request = req;
+    rx.init_audio.mode = SA3_INIT_AUDIO_INPAINT;
+    rx.init_audio.samples = src;
+    rx.init_audio.n_samp = src_n;
+    rx.init_audio.n_ch = src_ch;
+    rx.init_audio.sample_rate = src_sr;
+    rx.init_audio.inpaint_start = src_seconds;
+    rx.init_audio.inpaint_end = src_seconds + 6.0f;   /* six more seconds of music */
+
+    sa3_audio cont;
+    memset(&cont, 0, sizeof cont);
+    rc = sa3_generate_ex(ctx, &rx, &cont, err, (int)sizeof err);
+    if (rc != 0) { fprintf(stderr, "sa3_generate_ex failed (%d): %s\n", rc, err); free(src); sa3_free(ctx); return 1; }
+
+    memset(&meta, 0, sizeof meta);
+    meta.size = (uint32_t)sizeof meta;
+    if (sa3_last_meta(ctx, &meta) != 0) { fprintf(stderr, "sa3_last_meta failed\n"); free(src); sa3_free_audio(&cont); sa3_free(ctx); return 1; }
+    printf("continued to %.2fs; splice %s, kept 0-%.3fs, xfade %.0fms, gain %.3f, mask start %.3fs (pullback %.3fs)\n",
+           (double)cont.n_samp / cont.sample_rate, meta.splice_applied ? "on" : "off",
+           meta.splice_end_seconds, meta.splice_xfade_applied * 1000.0f, meta.splice_gain,
+           meta.mask_start_seconds, meta.mask_overlap_applied);
+    if (!meta.splice_applied) { fprintf(stderr, "splice did not run on a continuation\n"); free(src); sa3_free_audio(&cont); sa3_free(ctx); return 1; }
+
+    {
+        char cont_out[1024];
+        snprintf(cont_out, sizeof cont_out, "%s.continued.wav", out);
+        write_wav(cont_out, cont.samples, cont.n_samp, cont.n_ch, cont.sample_rate);
+        printf("wrote %s\n", cont_out);
+    }
+
+    free(src);
+    sa3_free_audio(&cont);
     sa3_free(ctx);
     return 0;
 }

--- a/tools/sa3-libtest.c
+++ b/tools/sa3-libtest.c
@@ -3,7 +3,7 @@
  *   sa3_init -> sa3_generate (with a progress callback) -> use samples -> sa3_free_audio -> sa3_free.
  *   usage: sa3-libtest ["prompt"] [out.wav] [cpu_threads]
  *
- * It then continues that clip through sa3_generate_ex to exercise the continuation splice, and
+ * It then continues that clip through sa3_generate_v2 to exercise the continuation splice, and
  * reads sa3_last_meta twice — once with a full struct, once with a deliberately undersized one,
  * which is the only thing that tests the `size` contract at all.
  */
@@ -124,21 +124,22 @@ int main(int argc, char** argv) {
     sa3_free_audio(&audio);
 
     const float src_seconds = (float)src_n / (float)src_sr;
-    sa3_request_ex rx;
+    sa3_request_v2 rx;
     memset(&rx, 0, sizeof rx);
-    rx.request = req;
-    rx.init_audio.mode = SA3_INIT_AUDIO_INPAINT;
-    rx.init_audio.samples = src;
-    rx.init_audio.n_samp = src_n;
-    rx.init_audio.n_ch = src_ch;
-    rx.init_audio.sample_rate = src_sr;
-    rx.init_audio.inpaint_start = src_seconds;
-    rx.init_audio.inpaint_end = src_seconds + 6.0f;   /* six more seconds of music */
+    rx.size = (uint32_t)sizeof rx;
+    rx.request.request = req;
+    rx.request.init_audio.mode = SA3_INIT_AUDIO_INPAINT;
+    rx.request.init_audio.samples = src;
+    rx.request.init_audio.n_samp = src_n;
+    rx.request.init_audio.n_ch = src_ch;
+    rx.request.init_audio.sample_rate = src_sr;
+    rx.request.init_audio.inpaint_start = src_seconds;
+    rx.request.init_audio.inpaint_end = src_seconds + 6.0f;   /* six more seconds of music */
 
     sa3_audio cont;
     memset(&cont, 0, sizeof cont);
-    rc = sa3_generate_ex(ctx, &rx, &cont, err, (int)sizeof err);
-    if (rc != 0) { fprintf(stderr, "sa3_generate_ex failed (%d): %s\n", rc, err); free(src); sa3_free(ctx); return 1; }
+    rc = sa3_generate_v2(ctx, &rx, &cont, err, (int)sizeof err);
+    if (rc != 0) { fprintf(stderr, "sa3_generate_v2 failed (%d): %s\n", rc, err); free(src); sa3_free(ctx); return 1; }
 
     memset(&meta, 0, sizeof meta);
     meta.size = (uint32_t)sizeof meta;

--- a/tools/sa3-server.cpp
+++ b/tools/sa3-server.cpp
@@ -661,6 +661,7 @@ bool parse_generate_request(yyjson_val* root, const std::string& adir,
     params.decode_chunk_size = I("decode_chunk_size", 0);
     params.decode_overlap    = I("decode_overlap", 32);
     params.loudness          = sa3::loudness_defaults_from_env();
+    params.splice            = sa3::splice_defaults_from_env();
 
     auto parse_json_float = [&](yyjson_val* v, float& out, const char* key) {
         if (!v) return true;


### PR DESCRIPTION
Needs validation from PC and clients other than sa3.cpp-ios, including sa3-server and the CLI. Can validate the sa3-server with the ableton extension, and might as well do a build of the iPlug2 project if we have time. This should help surface any issues in frontends that have not been built in quite some time.