### PR TITLE
Fix audio-to-audio shifted schedules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,9 @@ target_include_directories(sa3-latents-cache-test PRIVATE ${CMAKE_CURRENT_SOURCE
 add_executable(sa3-continuation-splice-test tests/continuation_splice_test.cpp)
 target_link_libraries(sa3-continuation-splice-test PRIVATE sa3)
 
+add_executable(sa3-sampling-schedule-test tests/sampling_schedule_test.cpp)
+target_link_libraries(sa3-sampling-schedule-test PRIVATE sa3)
+
 add_executable(sa3-set-wide-row-test tests/set_wide_row_test.cpp)
 target_link_libraries(sa3-set-wide-row-test PRIVATE sa3)
 
@@ -303,6 +306,7 @@ if(BUILD_TESTING)
     add_test(NAME sa3-lora-quant-merge-test COMMAND sa3-lora-quant-merge-test)
     add_test(NAME sa3-latents-cache-test COMMAND sa3-latents-cache-test)
     add_test(NAME sa3-continuation-splice-test COMMAND sa3-continuation-splice-test)
+    add_test(NAME sa3-sampling-schedule-test COMMAND sa3-sampling-schedule-test)
     add_test(NAME sa3-set-wide-row-test COMMAND sa3-set-wide-row-test)
     if(SA3_BUILD_SAT)
         add_test(NAME sa3-sat-sampling-test COMMAND sa3-sat-sampling-test)
@@ -348,6 +352,7 @@ if(BUILD_TESTING)
         sa3-train-prompt-test sa3-train-inpaint-test
         sa3-dit-lin-functional-test sa3-latents-cache-test sa3-continuation-splice-test
         PROPERTIES LABELS "non-gpu;training;lora")
+    set_tests_properties(sa3-sampling-schedule-test PROPERTIES LABELS "non-gpu;sampling")
     if(SA3_BUILD_SAT)
         set_tests_properties(sa3-sat-sampling-test sa3-sat-cli-help-test
                              sa3-sat-cli-model-option-test

--- a/src/sa3_pipeline.h
+++ b/src/sa3_pipeline.h
@@ -126,6 +126,29 @@ inline void dist_shift_defaults(const std::string& type, float& p1, float& p2, f
     else                     { p1 = 2000.0f; p2 = -6.2f;  p3 = 0.0f;   p4 = 2.0f;   } // LogSNR (medium, rate=0)
 }
 
+// Build the descending rectified-flow schedule for text generation and audio-to-audio. Distribution
+// shift is defined over normalized diffusion time [1, 0]; sigma_max then selects how far into that
+// curve an audio-to-audio request starts. Warping an already-scaled t (the old behaviour) could map
+// the first interior LogSNR step above sigma_max, violating every sampler's next <= current contract.
+inline std::vector<float> make_sa3_schedule(int steps, float sigma_max, int seq_len,
+                                            const std::string& type,
+                                            float p1, float p2, float p3, float p4) {
+    if (steps < 1) throw std::invalid_argument("sampling steps must be positive");
+    if (!(sigma_max > 0.0f && sigma_max <= 1.0f))
+        throw std::invalid_argument("sigma_max must be in (0, 1]");
+
+    std::vector<float> schedule((size_t)steps + 1);
+    schedule.front() = sigma_max;
+    for (int i = 1; i < steps; ++i) {
+        const float normalized_t = 1.0f - (float)i / (float)steps;
+        float warped = dist_shift_warp(type, normalized_t, seq_len, p1, p2, p3, p4);
+        if (!std::isfinite(warped)) warped = normalized_t;
+        schedule[(size_t)i] = std::clamp(sigma_max * warped, 0.0f, schedule[(size_t)i - 1]);
+    }
+    schedule.back() = 0.0f;
+    return schedule;
+}
+
 // Host classifier-free-guidance combine for the rf_denoiser objective, matching models/dit.py
 // 579-619 (the scalar/no-padding-mask case). v_cond/v_uncond are the two velocity predictions and
 // x is the current latent; sigma is the step's t. Writes the guided velocity to v_out. Layout is
@@ -1035,15 +1058,10 @@ inline GenResult Pipeline::generate(const GenParams& params) {
     profile_log(prof, "conditioning", wall_time_s() - t0);
 
     // ---------- schedule (SA3 distribution shift; default = LogSNR rate=0) ----------
-    // Linear t = sigma_max*(1 - i/steps), warped by the selected dist-shift, with endpoints
-    // re-anchored (t[0]=sigma_max, t[steps]=0) exactly as upstream build_schedule does.
-    std::vector<float> sigmas(steps+1);
-    for (int i = 0; i <= steps; i++) {
-        float t_in = sigma_max * (1.0f - (float)i / steps);
-        sigmas[i] = (i == 0) ? sigma_max
-                  : (i == steps) ? 0.0f
-                  : sa3::dist_shift_warp(dist_shift, t_in, eff_frames, ds_p1, ds_p2, ds_p3, ds_p4);
-    }
+    // Warp normalized diffusion time, then scale the curve by sigma_max for audio-to-audio.
+    // Endpoints stay anchored at sigma_max and zero and every step remains descending.
+    std::vector<float> sigmas = sa3::make_sa3_schedule(steps, sigma_max, eff_frames,
+                                                       dist_shift, ds_p1, ds_p2, ds_p3, ds_p4);
 
     // ---------- audio2audio: encode init audio -> latent z_init [latent, T] ----------
     // ---------- route this request's adapters ----------

--- a/tests/sampling_schedule_test.cpp
+++ b/tests/sampling_schedule_test.cpp
@@ -1,0 +1,49 @@
+#include "sa3_pipeline.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static int fails = 0;
+
+static void expect(bool ok, const std::string& message) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message.c_str()); ++fails; }
+}
+
+int main() {
+    std::printf("sampling_schedule_test\n");
+    const std::vector<std::string> shifts = {"LogSNR", "Flux", "Full", "None"};
+    const std::vector<float> starts = {0.01f, 0.5f, 0.85f, 1.0f};
+
+    for (const auto& shift : shifts) {
+        float p1 = 0.f, p2 = 0.f, p3 = 0.f, p4 = 0.f;
+        sa3::dist_shift_defaults(shift, p1, p2, p3, p4);
+        for (float sigma_max : starts) {
+            for (int steps : {1, 2, 8, 16}) {
+                const auto schedule = sa3::make_sa3_schedule(steps, sigma_max, 128,
+                                                             shift, p1, p2, p3, p4);
+                const std::string tag = shift + " sigma=" + std::to_string(sigma_max)
+                                      + " steps=" + std::to_string(steps);
+                expect(schedule.size() == (size_t)steps + 1, tag + ": wrong size");
+                expect(std::fabs(schedule.front() - sigma_max) < 1e-7f, tag + ": wrong start");
+                expect(schedule.back() == 0.0f, tag + ": wrong end");
+                for (size_t i = 1; i < schedule.size(); ++i) {
+                    expect(std::isfinite(schedule[i]), tag + ": non-finite timestep");
+                    expect(schedule[i] >= 0.0f && schedule[i] <= schedule[i - 1],
+                           tag + ": schedule is not descending");
+                }
+            }
+        }
+    }
+
+    // Regression: the old code warped 0.5 * 7/8 directly and produced ~0.83, above its 0.5 start.
+    float p1 = 0.f, p2 = 0.f, p3 = 0.f, p4 = 0.f;
+    sa3::dist_shift_defaults("LogSNR", p1, p2, p3, p4);
+    const auto transform = sa3::make_sa3_schedule(8, 0.5f, 128, "LogSNR", p1, p2, p3, p4);
+    expect(transform[1] < transform[0], "transform LogSNR first step must remain below sigma_max");
+
+    if (fails) { std::fprintf(stderr, "%d failure(s)\n", fails); return 1; }
+    std::printf("OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- build distribution-shift schedules in normalized diffusion time before scaling by the audio-to-audio noise level
- preserve descending sampler timesteps for every supported shift mode
- add a fast non-GPU regression test covering multiple noise levels and step counts

## Regression
The old schedule warped an already-scaled timestep, so nonlinear shifts could make the first interior timestep exceed the requested audio-to-audio start. The sampler invariant added later correctly exposed this as a \pingpong timesteps must satisfy 0 <= next <= current <= 1\ failure.

## Verification
- \sa3-sampling-schedule-test\ passes in Release
- audio-to-audio transform confirmed working in the iPlug2 project